### PR TITLE
Renaming common_clang to opencl_clang - BiFModule

### DIFF
--- a/IGC/BiFModule/CMakeLists.txt
+++ b/IGC/BiFModule/CMakeLists.txt
@@ -103,22 +103,26 @@
     "$<TARGET_FILE:CLANG_7Z_OUTPUT>"
   )
 
+  if(NOT DEFINED COMMON_CLANG_LIBRARY_NAME)
+    set(COMMON_CLANG_LIBRARY_NAME common_clang)
+  endif()
+
   if(WIN32)
-    set(COMMON_CLANG_LIB_NAME "common_clang${_cpuSuffix}${CMAKE_SHARED_LIBRARY_SUFFIX}")
-    set(COMMON_CLANG_LIB_PATH "${IGC_OPTION__OUTPUT_DIR}/${CMAKE_BUILD_TYPE}/${COMMON_CLANG_LIB_NAME}")
+    set(COMMON_CLANG_LIB_FULL_NAME "${COMMON_CLANG_LIBRARY_NAME}${_cpuSuffix}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    set(COMMON_CLANG_LIB_PATH "${COMMON_CLANG_LIBRARY_NAME}${IGC_OPTION__OUTPUT_DIR}/${CMAKE_BUILD_TYPE}/${COMMON_CLANG_LIB_FULL_NAME}")
   else()
-    set(COMMON_CLANG_LIB_NAME "libcommon_clang${CMAKE_SHARED_LIBRARY_SUFFIX}")
-    set(COMMON_CLANG_LIB_PATH "${IGC_OPTION__OUTPUT_DIR}/${COMMON_CLANG_LIB_NAME}")
+    set(COMMON_CLANG_LIB_FULL_NAME "lib${COMMON_CLANG_LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    set(COMMON_CLANG_LIB_PATH "${IGC_OPTION__OUTPUT_DIR}/${COMMON_CLANG_LIB_FULL_NAME}")
   endif()
   
   # Add step to preform the extraction
   add_custom_command(
     OUTPUT ${IGC_TARGET__TOOLS_CLANG_DIR}/clang${CMAKE_EXECUTABLE_SUFFIX}
-	OUTPUT ${IGC_TARGET__TOOLS_CLANG_DIR}/${COMMON_CLANG_LIB_NAME}
+	OUTPUT ${IGC_TARGET__TOOLS_CLANG_DIR}/${COMMON_CLANG_LIB_FULL_NAME}
     COMMAND "${CMAKE_COMMAND}" -E make_directory "${IGC_TARGET__TOOLS_CLANG_DIR}"
     COMMAND ${_extractCmd}
     COMMAND "${CMAKE_COMMAND}" -E touch_nocreate "${IGC_TARGET__TOOLS_CLANG_DIR}/clang${CMAKE_EXECUTABLE_SUFFIX}"
-	COMMAND "${CMAKE_COMMAND}" -E touch_nocreate "${IGC_TARGET__TOOLS_CLANG_DIR}/${COMMON_CLANG_LIB_NAME}"
+	COMMAND "${CMAKE_COMMAND}" -E touch_nocreate "${IGC_TARGET__TOOLS_CLANG_DIR}/${COMMON_CLANG_LIB_FULL_NAME}"
     DEPENDS CLANG_7Z
     COMMENT "Extracting Clang packages using: ${_extractCmd}"
   )
@@ -139,7 +143,7 @@
 
     add_dependencies(GetClang UnzipClang)
 
-    set_property(TARGET common_clang_dll PROPERTY "IMPORTED_LOCATION" "${IGC_TARGET__TOOLS_CLANG_DIR}/${COMMON_CLANG_LIB_NAME}")
+    set_property(TARGET common_clang_dll PROPERTY "IMPORTED_LOCATION" "${IGC_TARGET__TOOLS_CLANG_DIR}/${COMMON_CLANG_LIB_FULL_NAME}")
   else()
     # Do not use precompiled common clang.
     message(STATUS "Precompiled common clang bundle ${_clang7zLocation} does not exist. Try to compile from sources.")
@@ -164,7 +168,7 @@
       add_subdirectory(${IGC_CCLANG_HOME_DIR} ${IGC_CCLANG_BUILD_DIR})
       add_dependencies(GetClang "${CCLANG_LIB_NAME}")
 
-      set_property(TARGET common_clang_dll PROPERTY "IMPORTED_LOCATION" "${IGC_CCLANG_BUILD_DIR}/install/lib/${COMMON_CLANG_LIB_NAME}")
+      set_property(TARGET common_clang_dll PROPERTY "IMPORTED_LOCATION" "${IGC_CCLANG_BUILD_DIR}/install/lib/${COMMON_CLANG_LIB_FULL_NAME}")
     else()
       message(FATAL_ERROR "Can not compile common clang: unknown location of common clang sources")
     endif()

--- a/IGC/OCLFE/igd_fcl_mcl/headers/clang_tb.h
+++ b/IGC/OCLFE/igd_fcl_mcl/headers/clang_tb.h
@@ -68,6 +68,13 @@ namespace TC
     void* pModule           = nullptr;
     PFcnCCCompile pCompile  = nullptr;
     const char *pModuleName = nullptr;
+#ifndef _WIN32
+    // Due to clash of names between CPU OCL common clang and GPU common clang
+    // we rename the libcommon_clang.so. While the change is not introduced
+    // to Neo, try to load from new location and if it fails load the old name.
+    // TODO: remove this and related code when Neo switches.
+    const char *pModuleOldName = nullptr;
+#endif
 
     CCModuleStruct()
     {
@@ -81,7 +88,8 @@ namespace TC
       pModuleName = "common_clang32.dll";
 #endif
 #else
-      pModuleName = "libcommon_clang.so";
+      pModuleOldName = "libcommon_clang.so";
+      pModuleName    = "libopencl_clang.so";
 #endif
     }
   };

--- a/IGC/OCLFE/igd_fcl_mcl/source/clang_tb.cpp
+++ b/IGC/OCLFE/igd_fcl_mcl/source/clang_tb.cpp
@@ -272,6 +272,11 @@ namespace TC
 #else
 				// Both 32 and 64 bit for non-Windows OS
 				CCModule.pModule = dlopen(CCModule.pModuleName, RTLD_NOW);
+				if (NULL == CCModule.pModule)
+				{
+					// Try to load with old name. See header file for explanation.
+					CCModule.pModule = dlopen(CCModule.pModuleOldName, RTLD_NOW);
+				}
 				if (NULL != CCModule.pModule)
 				{
 					CCModule.pCompile = (CCModuleStruct::PFcnCCCompile)dlsym(CCModule.pModule, "Compile");


### PR DESCRIPTION
This is the BiFModule part of fix for issue described in: https://github.com/intel/compute-runtime/issues/21
With https://github.com/intel/opencl-clang/pull/2 we will be adding an ability to change Common Clang's library name. As NEO runtime builds Clang indirectly via BiFModule, we need to respect the COMMON_CLANG_LIBRARY_NAME setting here.