### PR TITLE
build: drop IGC_OPTION__OUTPUT_DIR from readme description

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $ mkdir build
 4. Build IGC using commands:
 ```
 $ cd build
-$ cmake -DIGC_OPTION__OUTPUT_DIR=../igc-install/Release ../igc/IGC
+$ cmake ../igc/IGC
 $ make -j`nproc`
 ```
 


### PR DESCRIPTION
After cb807eea IGC_OPTION__OUTPUT_DIR becomes an optional
configuration setting. We can drop it from the README description
to simplify IGC build instruction.

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>