### PR TITLE
LocalScheduler must be compiled explicitly as STATIC

### DIFF
--- a/visa/LocalScheduler/CMakeLists.txt
+++ b/visa/LocalScheduler/CMakeLists.txt
@@ -48,7 +48,7 @@ if(WIN32)
   add_definitions(-D_HAS_EXCEPTIONS=0)
 endif()
 
-add_library(LocalScheduler ${LocalScheduler_SOURCES} ${LocalScheduler_HEADERS})
+add_library(LocalScheduler STATIC ${LocalScheduler_SOURCES} ${LocalScheduler_HEADERS})
 
 if(IGC_BUILD AND MSVC)
 #set up standard defines from the common WDK path.


### PR DESCRIPTION
If cmake is configured with BUILD_SHARED_LIBS:BOOL=ON,
LocalScheduler will be compiled as a shared library.  Because of
its circular relationship with other parts of igc, many undefined
references will result.  Building explicitly as static solves the
issue.

