### PR TITLE
Check llvm::Expected before use

### DIFF
--- a/IGC/Compiler/Optimizer/PreCompiledFuncImport.cpp
+++ b/IGC/Compiler/Optimizer/PreCompiledFuncImport.cpp
@@ -402,7 +402,10 @@ bool PreCompiledFuncImport::runOnModule(Module &M)
                 //    llvm::getLazyBitcodeModule(MemoryBufferRef(BitRef.str(), ""), M.getContext());
                 llvm::Expected<std::unique_ptr<llvm::Module>> ModuleOrErr =
                     llvm::parseBitcodeFile(MemoryBufferRef(BitRef.str(), ""), M.getContext());
-                assert(ModuleOrErr && "llvm getLazyBitcodeModule - FAILED to parse bitcode");
+                if (llvm::Error EC = ModuleOrErr.takeError())
+                {
+                    assert(0 && "llvm getLazyBitcodeModule - FAILED to parse bitcode");
+                }
                 std::unique_ptr<llvm::Module> m_pBuiltinModule = std::move(*ModuleOrErr);
                 assert(m_pBuiltinModule && "llvm version mismatch - could not load llvm module");
 


### PR DESCRIPTION
Fixes: #77

That's effectively reuse of the same approach already used in IGC elsewhere:
https://github.com/intel/intel-graphics-compiler/blob/952d4d1f210cfb5573aa73c7a7a4d1119237f901/IGC/Compiler/Optimizer/BuiltInFuncImport.cpp#L378