### PR TITLE
cif: move template implementation to other methods location

### DIFF
--- a/IGC/AdaptorOCL/cif/cif/builtins/builtins_registry.cpp
+++ b/IGC/AdaptorOCL/cif/cif/builtins/builtins_registry.cpp
@@ -39,7 +39,7 @@ namespace Builtins {
 using AllBuiltinsListT =  InterfacesList<CIF::Builtins::Buffer>;
 
 bool IsBuiltin(InterfaceId_t intId){
-    return AllBuiltinsListT::ContainsInterface(intId);
+    return AllBuiltinsListT::template forwardToOne<Helpers::IsInterfaceIdFwdToOne, bool>(intId, false);
 }
 
 ICIF *Create(InterfaceId_t entryPointInterface, Version_t version, ICIF *parentInterface){

--- a/IGC/AdaptorOCL/cif/cif/common/cif.h
+++ b/IGC/AdaptorOCL/cif/cif/common/cif.h
@@ -289,14 +289,6 @@ template <> struct InterfacePack<> {
 };
 
 
-struct IsInterfaceIdFwdToOne
-{
-    template<template <Version_t> class Interface>
-    static bool Call(){
-        return true;
-    }
-};
-
 /// Storage for versioned CIF interfaces
 /// Useful in operations on sets of interfaces
 template <template <Version_t> class... SupportedInterfaces>
@@ -325,10 +317,6 @@ struct InterfacesList {
 #else
     return GetNumInterfacesImpl<SupportedInterfaces...>();
 #endif
-  }
-
-  static bool ContainsInterface(InterfaceId_t id){
-      return forwardToOne<IsInterfaceIdFwdToOne, bool, bool>(id, false);
   }
 
 protected:

--- a/IGC/AdaptorOCL/cif/cif/export/cif_main_impl.h
+++ b/IGC/AdaptorOCL/cif/cif/export/cif_main_impl.h
@@ -36,6 +36,13 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 namespace CIF {
 
 namespace Helpers {
+  struct IsInterfaceIdFwdToOne {
+    template<template <Version_t> class Interface>
+    static bool Call(){
+      return true;
+    }
+  };
+
   struct ForwardCreateInterfaceImpl {
     template <template <Version_t> class Interface, typename ... ArgsT>
     static Interface<CIF::BaseVersion> *Call(Version_t version, ArgsT && ... args) {


### PR DESCRIPTION
when compiling with gcc-9, this template doesn't work as the
DataValueT can't be interpreted correctly.

Moved everything to the same place so that compiler can be happy

Fixes: #92

Signed-off-by: Daniel Charles <daniel.charles@intel.com>