### PR TITLE
fix header inclusion

### DIFF
--- a/IGC/AdaptorOCL/Upgrader/llvm9/BitcodeReader.h
+++ b/IGC/AdaptorOCL/Upgrader/llvm9/BitcodeReader.h
@@ -15,7 +15,7 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Bitcode/BitCodes.h"
+#include "llvm/Bitstream/BitCodes.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"


### PR DESCRIPTION
The header BitCodes.h has moved in llvm9:

https://github.com/llvm-mirror/llvm/commit/742690b61b65feb08fd4235a58b1bd1eab98d0ed