### PR TITLE
Unbreak build with libc++ and LLVM 10

### DIFF
--- a/IGC/OCLFE/igd_fcl_mcl/headers/clang_tb.h
+++ b/IGC/OCLFE/igd_fcl_mcl/headers/clang_tb.h
@@ -30,6 +30,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "TranslationBlock.h"
 #include <string>
 #include <memory>
+#include <vector>
 
 #include "LoadBuffer.h"
 #include "AdaptorOCL/CLElfLib/ElfReader.h"


### PR DESCRIPTION
Due to change in LLVM headers `<vector>` is no longer implicitly included but GCC still manages to bootleg it via libstdc++ headers.
```
In file included from /usr/local/lib/gcc9/include/c++/functional:62,
                 from /usr/local/lib/gcc9/include/c++/pstl/glue_algorithm_defs.h:13,
                 from /usr/local/lib/gcc9/include/c++/algorithm:71,
                 from /usr/local/llvm10/include/llvm/ADT/iterator.h:13,
                 from /usr/local/llvm10/include/llvm/ADT/STLExtras.h:20,
                 from /usr/local/llvm10/include/llvm/ADT/StringRef.h:12,
                 from /usr/local/llvm10/include/llvm/IR/DiagnosticHandler.h:15,
                 from /usr/local/llvm10/include/llvm/IR/LLVMContext.h:18,
                 from .../intel-graphics-compiler-igc-1.0.3627/IGC/common/debug/Debug.hpp:29,
                 from .../intel-graphics-compiler-igc-1.0.3627/IGC/common/Types.hpp:31,
                 from .../intel-graphics-compiler-igc-1.0.3627/IGC/Compiler/DebugInfo/VISAIDebugEmitter.hpp:32,
                 from .../intel-graphics-compiler-igc-1.0.3627/IGC/Compiler/DebugInfo/VISADebugEmitter.hpp:30,
                 from .../intel-graphics-compiler-igc-1.0.3627/IGC/Compiler/DebugInfo/VISADebugEmitter.cpp:36:
/usr/local/lib/gcc9/include/c++/vector:58:2: error: #error bootlegging test
   58 | #error bootlegging test
      |  ^~~~~
```
