### PR TITLE
Fix build with system LLVM: do not hardcode LLVM library path

### DIFF
--- a/IGC/CMakeLists.txt
+++ b/IGC/CMakeLists.txt
@@ -3271,8 +3271,12 @@ endif()
 if(LLVM_LINK_LLVM_DYLIB)
     # LLVM was built and configured in a way that tools (in our case IGC) should be linked
     # against single LLVM dynamic library.
-    set(IGC_BUILD__LLVM_LIBS_TO_LINK "/usr/local/lib/libLLVM-${LLVM_VERSION_MAJOR}.so")
-    message(STATUS "[IGC] Link against LLVM dylib ${IGC_BUILD__LLVM_LIBS_TO_LINK}")
+    find_library(IGC_BUILD__LLVM_LIBS_TO_LINK "libLLVM-${LLVM_VERSION_MAJOR}.so")
+    if(IGC_BUILD__LLVM_LIBS_TO_LINK)
+      message(STATUS "[IGC] Link against LLVM dylib ${IGC_BUILD__LLVM_LIBS_TO_LINK}")
+    else()
+      message(FATAL_ERROR "[IGC] Could not find the LLVM dylib. Aborting.")
+    endif()
 else()
     # LLVM was built into multiple libraries (static or shared).
     message(STATUS "[IGC] Link against LLVM static or shared component libs")


### PR DESCRIPTION
The build currently fails on some platforms (namely on Arch Linux) when using system LLVM:
```
make[2]: *** No rule to make target '/usr/local/lib/libLLVM-10.so', needed by 'IGC/Release/elf_packager'.  Stop.
```

IGC 1.0.3826 was building fine.

That's because the LLVM link library is now being hardcoded with a `/usr/local` path on the CMake files since commit 6124673, but not all systems will install the library on this location. On Arch Linux, the LLVM library is installed on `/usr/lib`, and `find_library()` will correctly get the library full path in a system-agnostic manner.

Also on this commit: continue the CMake execution only if the LVVM library is found, to avoid such build errors on the middle of the compilation.