### PR TITLE
Add workaround for gcc 10 internal compiler error

### DIFF
--- a/visa/iga/IGALibrary/Backend/Native/Field.hpp
+++ b/visa/iga/IGALibrary/Backend/Native/Field.hpp
@@ -150,8 +150,8 @@ namespace iga
         // a simple encoded field (single contiguous)
         constexpr Field(const char *_name, int offset, int length)
             : name(_name)
-            , fragments{Fragment(_name, offset, length)}
         {
+            fragments[0] = Fragment(_name, offset, length);
         }
         // a zero fill field or must-be-zero field
         constexpr Field(const char *_name,             int length,


### PR DESCRIPTION
There is a regression in recent gcc (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95241),
that make IGC fail to compile:
In file included from /home/tab/dev/external/oneapi/igc/visa/iga/IGALibrary/Models/Models.cpp:7:
/home/tab/dev/external/oneapi/igc/visa/iga/IGALibrary/Models/bxml/Model7P5.hpp:1258:34:   in ‘constexpr’ expansion of ‘iga::Field(((const char*)"MathFC"), 24, 4)’
/home/tab/dev/external/oneapi/igc/visa/iga/IGALibrary/Models/bxml/Model7P5.hpp:2085:5: internal compiler error: in tree_to_uhwi, at tree.h:4519
 2085 |     };
      |     ^