### PR TITLE
Fixing patch that was causing a configure failure.

### DIFF
--- a/external/llvm/releases/10.0.0/patches_external/fix_for_opt_buildbreak.patch
+++ b/external/llvm/releases/10.0.0/patches_external/fix_for_opt_buildbreak.patch
@@ -7,6 +7,6 @@
    Core
    Coroutines
 +  Demangle
+   Extensions
    IPO
    IRReader
-   InstCombine


### PR DESCRIPTION
Patch fix_for_opt_buildbreak.patch was not applying cleanly as the target file
had changed on the llvm branch.