### PR TITLE
Unbreak build with libc++

### DIFF
--- a/IGC/VectorCompiler/include/vc/GenXOpts/Utils/KernelInfo.h
+++ b/IGC/VectorCompiler/include/vc/GenXOpts/Utils/KernelInfo.h
@@ -33,6 +33,8 @@ IN THE SOFTWARE.
 #include "llvm/GenXIntrinsics/GenXMetadata.h"
 #include "Probe/Assertion.h"
 
+#include <unordered_map>
+
 namespace llvm {
 namespace genx {
 


### PR DESCRIPTION
Regressed in igc-1.0.6646, see [error log](https://github.com/intel/intel-graphics-compiler/files/6150629/intel-graphics-compiler-1.0.6646.log). GCC bootlegs `<unordered_map>` via libstdc++ headers.
```
In file included from /usr/include/c++/functional:61,
                 from /usr/include/c++/pstl/glue_algorithm_defs.h:13,
                 from /usr/include/c++/algorithm:74,
                 from /usr/include/llvm/ADT/Hashing.h:51,
                 from /usr/include/llvm/ADT/ArrayRef.h:12,
                 from IGC/VectorCompiler/lib/GenXCodeGen/GenX.h:28,
                 from IGC/VectorCompiler/lib/GenXCodeGen/GenXOCLInfoExtractor.cpp:25:
/usr/include/c++/unordered_map:32:2: error: #error bootlegging test
```


