### PR TITLE
Type Legalization issue with resolving PhiNode Value

### DIFF
--- a/IGC/AdaptorCommon/TypesLegalizationPass.cpp
+++ b/IGC/AdaptorCommon/TypesLegalizationPass.cpp
@@ -245,7 +245,7 @@ TypesLegalizationPass::ResolveValue( Instruction *ip,Value *val,SmallVector<unsi
   }
   else if (PHINode* phi = dyn_cast<PHINode>(val))
   {
-      IRBuilder<> builder(&(*ip->getParent()->getFirstInsertionPt()));
+      IRBuilder<> builder(phi);
       PHINode* newPhi = builder.CreatePHI(ip->getType(), phi->getNumIncomingValues());
       for (unsigned i = 0; i < phi->getNumIncomingValues(); i++)
       {


### PR DESCRIPTION
This Part of legalization is assuming that both PhiNode and the ExtractValue are in the same block which is not always the case as seen by the code below

endIndirectCallBB.i: ; preds = %customTriangleIntersectionFunctionVisible.exit.i, %sphereIntersectionFunctionVisible.exit.i
%815 = phi %struct.BoundingBoxIntersection [ %oldret2.i.i, %sphereIntersectionFunctionVisible.exit.i ], [ %oldret2.i6.i, %customTriangleIntersectionFunctionVisible.exit.i ]
%816 = extractvalue %struct.BoundingBoxIntersection %815, 0
%817 = and i8 %816, 1
%tobool.i.i.i = icmp eq i8 %817, 0
br i1 %tobool.i.i.i, label %if.end.i.i.i, label %if.then.i.i.i

if.then.i.i.i: ; preds = %endIndirectCallBB.i
%818 = extractvalue %struct.BoundingBoxIntersection %815, 1
%819 = getelementptr inbounds %struct._my_struct_t, %struct._my_struct_t* %0, i64 0, i32 31
store i32 2, i32* %819, align 4, !tbaa !229
%820 = getelementptr inbounds %struct._my_struct_t, %struct._my_struct_t* %0, i64 0, i32 24
store float %818, float* %820, align 16, !tbaa !192