### PR TITLE
emitSymbolRelocation issue

### DIFF
--- a/IGC/Compiler/CISACodeGen/EmitVISAPass.cpp
+++ b/IGC/Compiler/CISACodeGen/EmitVISAPass.cpp
@@ -10630,8 +10630,8 @@ void EmitPass::emitSymbolRelocation(Function& F)
             }
             else if (Constant* C = dyn_cast<Constant>(*it))
             {
-                if (C->isConstantUsed())
-                    return ValueUsedInFunction(C, currFunc);
+                if (C->isConstantUsed() && ValueUsedInFunction(C, currFunc))
+                    return true;
             }
         }
         return false;


### PR DESCRIPTION
Basically the recursion is not valid if we return in constant case. Imagine the first user is a constant, and say we recurse until value is not used, we then come back to top of the stack and return false without going into the other uses. Base case, after the loop, takes care of returning false at the right time.