### PR TITLE
Fix missing include

### DIFF
--- a/visa/iga/IGALibrary/IR/RegDeps.cpp
+++ b/visa/iga/IGALibrary/IR/RegDeps.cpp
@@ -10,6 +10,7 @@ SPDX-License-Identifier: MIT
 #include "../asserts.hpp"
 #include "../bits.hpp"
 
+#include <limits>
 #include <sstream>
 #include <cstring>
 


### PR DESCRIPTION
Without this we get `error: ‘numeric_limits’ is not a member of ‘std’`. This is due to an implicit dependency change in modern compilers.