### PR TITLE
LLVM 13 build fixes

### DIFF
--- a/IGC/AdaptorCommon/LegalizeFunctionSignatures.cpp
+++ b/IGC/AdaptorCommon/LegalizeFunctionSignatures.cpp
@@ -377,7 +377,11 @@ void LegalizeFunctionSignatures::FixFunctionBody(Module& M)
             }
 
             // Clone the old function body into the new
+#if LLVM_VERSION_MAJOR >= 13
+            CloneFunctionInto(pNewFunc, pFunc, VMap, CloneFunctionChangeType::DifferentModule, Returns);
+#else
             CloneFunctionInto(pNewFunc, pFunc, VMap, true, Returns);
+#endif
 
             // Merge the BB for when extra instructions were created
             BasicBlock* ClonedEntryBB = cast<BasicBlock>(VMap[&*pFunc->begin()]);

--- a/IGC/AdaptorOCL/OCL/sp/spp_g8.cpp
+++ b/IGC/AdaptorOCL/OCL/sp/spp_g8.cpp
@@ -407,7 +407,11 @@ bool createElfFileName(std::string &name, unsigned int maxNameLen, SIMDMode simd
         unsigned int mode = sys::fs::perms::all_read | sys::fs::perms::all_write;
         // Every '%' will be replaced with a random character (0-9 or a-f), taking care of multithreaded compilations
         if (std::error_code EC = sys::fs::createUniqueFile(
-            uniqueLockFileName, uniqueLockFileID, resultUniqueLockFileName, mode))
+            uniqueLockFileName, uniqueLockFileID, resultUniqueLockFileName,
+#if LLVM_VERSION_MAJOR >= 13
+            llvm::sys::fs::OF_None,
+#endif
+            mode))
         {
             IGC_ASSERT_MESSAGE(false, "A uniquely named file not created");
             retValue = false;

--- a/IGC/AdaptorOCL/SPIRV/SPIRVReader.cpp
+++ b/IGC/AdaptorOCL/SPIRV/SPIRVReader.cpp
@@ -97,7 +97,11 @@ isOpenCLKernel(SPIRVFunction *BF) {
 __attr_unused static void
 dumpLLVM(Module *M, const std::string &FName) {
   std::error_code EC;
+#if LLVM_VERSION_MAJOR >= 13
+  raw_fd_ostream FS(FName, EC, sys::fs::OF_None);
+#else
   raw_fd_ostream FS(FName, EC, sys::fs::F_None);
+#endif
   if (!FS.has_error()) {
     FS << *M;
   }
@@ -2452,7 +2456,11 @@ SPIRVToLLVM::postProcessFunctionsReturnStruct(Function *F) {
           NewArgIt->setName(OldArgIt->getName());
           VMap[&*OldArgIt] = &*NewArgIt;
       }
+#if LLVM_VERSION_MAJOR >= 13
+      CloneFunctionInto(NewF, F, VMap, CloneFunctionChangeType::DifferentModule, Returns);
+#else
       CloneFunctionInto(NewF, F, VMap, true, Returns);
+#endif
       auto DL = M->getDataLayout();
       const auto ptrSize = DL.getPointerSize();
 

--- a/IGC/AdaptorOCL/SPIRV/SPIRVUtil.cpp
+++ b/IGC/AdaptorOCL/SPIRV/SPIRVUtil.cpp
@@ -67,7 +67,11 @@ namespace igc_spv{
 void
 saveLLVMModule(Module *M, const std::string &OutputFile) {
   std::error_code EC;
+#if LLVM_VERSION_MAJOR >= 13
+  llvm::ToolOutputFile Out(OutputFile.c_str(), EC, sys::fs::OF_None);
+#else
   llvm::ToolOutputFile Out(OutputFile.c_str(), EC, sys::fs::F_None);
+#endif
   IGC_ASSERT_EXIT_MESSAGE((!EC), "Failed to open file");
   IGCLLVM::WriteBitcodeToFile(M, Out.os());
   Out.keep();
@@ -354,7 +358,11 @@ mutateCallInst(Module *M, CallInst *CI,
       }
     }
 
+#if LLVM_VERSION_MAJOR >= 13
+    CloneFunctionInto(NewF, OldF, VMap, CloneFunctionChangeType::DifferentModule, Returns);
+#else
     CloneFunctionInto(NewF, OldF, VMap, true, Returns);
+#endif
 
     // Merge the basic block with Load instruction with the original entry basic block.
     BasicBlock* ClonedEntryBB = cast<BasicBlock>(VMap[&*OldF->begin()]);

--- a/IGC/Compiler/GenTTI.cpp
+++ b/IGC/Compiler/GenTTI.cpp
@@ -461,7 +461,11 @@ namespace llvm {
   // [LLVM-UPGRADE] moved from getCallCost to getUserCost
   // https://github.com/llvm/llvm-project/commit/2641a19981e71c887bece92074e00d1af3e716c9#diff-dd4bd65dc55d754674d9a945a0d22911
 
+#if LLVM_VERSION_MAJOR >= 13
+  InstructionCost GenIntrinsicsTTIImpl::getUserCost(const User *U, ArrayRef<const Value *> Operands, TTI::TargetCostKind CostKind)
+#else
   int GenIntrinsicsTTIImpl::getUserCost(const User *U, ArrayRef<const Value *> Operands, TTI::TargetCostKind CostKind)
+#endif
   {
       const Function* F = dyn_cast<Function>(U);
       if(F != nullptr)

--- a/IGC/Compiler/GenTTI.h
+++ b/IGC/Compiler/GenTTI.h
@@ -72,7 +72,11 @@ namespace llvm
 #endif
         );
 #else
+#if LLVM_VERSION_MAJOR >= 13
+       InstructionCost getUserCost(const User *U, ArrayRef<const Value *> Operands,
+#else
        int getUserCost(const User *U, ArrayRef<const Value *> Operands,
+#endif
                       TTI::TargetCostKind CostKind);
 #endif
 

--- a/IGC/Compiler/Optimizer/BuiltInFuncImport.cpp
+++ b/IGC/Compiler/Optimizer/BuiltInFuncImport.cpp
@@ -880,7 +880,11 @@ void BIImport::removeFunctionBitcasts(Module& M)
                                 pDstFunc,
                                 funcTobeChanged,
                                 operandMap,
+#if LLVM_VERSION_MAJOR >= 13
+                                CloneFunctionChangeType::LocalChangesOnly,
+#else
                                 false,
+#endif
                                 Returns,
                                 "");
 

--- a/IGC/Compiler/Optimizer/CodeAssumption.cpp
+++ b/IGC/Compiler/Optimizer/CodeAssumption.cpp
@@ -272,7 +272,12 @@ bool CodeAssumption::addAssumption(Function* F, AssumptionCache* AC)
                     // Register assumption
                     if (AC)
                     {
+#if LLVM_VERSION_MAJOR >= 13
+                        if (auto *aI = dyn_cast<AssumeInst>(assumeInst))
+                            AC->registerAssumption(aI);
+#else
                         AC->registerAssumption(assumeInst);
+#endif
                     }
 
                     assumptionAdded[PN] = 1;

--- a/IGC/Compiler/Optimizer/OpenCLPasses/AddressSpaceAliasAnalysis/AddressSpaceAliasAnalysis.cpp
+++ b/IGC/Compiler/Optimizer/OpenCLPasses/AddressSpaceAliasAnalysis/AddressSpaceAliasAnalysis.cpp
@@ -7,6 +7,9 @@ SPDX-License-Identifier: MIT
 ============================= end_copyright_notice ===========================*/
 
 #include "llvm/Config/llvm-config.h"
+#if LLVM_VERSION_MAJOR >= 13
+#include <llvm/Analysis/AliasAnalysis.h>
+#endif
 #include "Compiler/Optimizer/OpenCLPasses/AddressSpaceAliasAnalysis/AddressSpaceAliasAnalysis.h"
 #include "Compiler/CodeGenPublic.h"
 #include "Compiler/IGCPassSupport.h"
@@ -44,7 +47,11 @@ namespace {
             PointerType* PtrTy2 = dyn_cast<PointerType>(LocB.Ptr->getType());
 
             if (!PtrTy1 || !PtrTy2)
+#if LLVM_VERSION_MAJOR >= 13
+                return AliasResult::Kind::NoAlias;
+#else
                 return NoAlias;
+#endif
 
             unsigned AS1 = PtrTy1->getAddressSpace();
             unsigned AS2 = PtrTy2->getAddressSpace();
@@ -61,21 +68,33 @@ namespace {
                 AS1 != ADDRESS_SPACE_GENERIC &&
                 AS2 != ADDRESS_SPACE_GENERIC &&
                 AS1 != AS2)
+#if LLVM_VERSION_MAJOR >= 13
+                return AliasResult::Kind::NoAlias;
+#else
                 return NoAlias;
+#endif
 
 
             // Shared local memory doesn't alias any statefull memory.
             if ((AS1 == ADDRESS_SPACE_LOCAL && AS2 > ADDRESS_SPACE_NUM_ADDRESSES) ||
                 (AS1 > ADDRESS_SPACE_NUM_ADDRESSES && AS2 == ADDRESS_SPACE_LOCAL))
             {
+#if LLVM_VERSION_MAJOR >= 13
+                return AliasResult::Kind::NoAlias;
+#else
                 return NoAlias;
+#endif
             }
 
             // Private memory doesn't alias any stateful memory
             if ((AS1 == ADDRESS_SPACE_PRIVATE && AS2 > ADDRESS_SPACE_NUM_ADDRESSES) ||
                 (AS1 > ADDRESS_SPACE_NUM_ADDRESSES && AS2 == ADDRESS_SPACE_PRIVATE))
             {
+#if LLVM_VERSION_MAJOR >= 13
+                return AliasResult::Kind::NoAlias;
+#else
                 return NoAlias;
+#endif
             }
 
 
@@ -107,7 +126,11 @@ namespace {
                     if ((resourceType[0] != resourceType[1]) || // different resource types
                         (isDirectAccess[0] && isDirectAccess[1] && resourceIndex[0] != resourceIndex[1])) // direct access to different BTIs
                     {
+#if LLVM_VERSION_MAJOR >= 13
+                        return AliasResult::Kind::NoAlias;
+#else
                         return NoAlias;
+#endif
                     }
                 }
             }

--- a/IGC/Compiler/Optimizer/OpenCLPasses/PrivateMemory/PrivateMemoryResolution.cpp
+++ b/IGC/Compiler/Optimizer/OpenCLPasses/PrivateMemory/PrivateMemoryResolution.cpp
@@ -18,6 +18,9 @@ SPDX-License-Identifier: MIT
 #include "llvmWrapper/IR/DerivedTypes.h"
 #include "llvm/Transforms/Utils/Local.h"
 #include "llvm/IR/DataLayout.h"
+#if LLVM_VERSION_MAJOR >= 13
+#include "llvm/IR/DebugInfo.h"
+#endif
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/Dominators.h"
 #include "common/LLVMWarningsPop.hpp"

--- a/IGC/DebugInfo/DwarfDebug.cpp
+++ b/IGC/DebugInfo/DwarfDebug.cpp
@@ -923,9 +923,17 @@ CompileUnit* DwarfDebug::constructCompileUnit(DICompileUnit* DIUnit)
                 {
                     std::string str;
                     str = "Intel OpenCL ";
+#if LLVM_VERSION_MAJOR >= 13
+                    str += toString(op1->getValue()->getUniqueInteger(), 10, false);
+#else
                     str += op1->getValue()->getUniqueInteger().toString(10, false);
+#endif
                     str += ".";
+#if LLVM_VERSION_MAJOR >= 13
+                    str += toString(op2->getValue()->getUniqueInteger(), 10, false);
+#else
                     str += op2->getValue()->getUniqueInteger().toString(10, false);
+#endif
 
                     NewCU->addString(Die, dwarf::DW_AT_description, llvm::StringRef(str));
                 }

--- a/IGC/DebugInfo/StreamEmitter.cpp
+++ b/IGC/DebugInfo/StreamEmitter.cpp
@@ -390,11 +390,23 @@ StreamEmitter::StreamEmitter(raw_pwrite_stream& outStream,
 
     MCRegisterInfo* regInfo = nullptr;
 
+    Triple triple = Triple(GetTargetTriple());
+
+#if LLVM_VERSION_MAJOR >= 13
+    // Create new MC context
+    m_pContext = new MCContext(Triple(GetTargetTriple()),
+                               (const llvm::MCAsmInfo*)m_pAsmInfo, regInfo,
+                               /*MSTI=*/(const llvm::MCSubtargetInfo *)nullptr, m_pSrcMgr);
+
+    m_pObjFileInfo->initMCObjectFileInfo(*m_pContext, false);
+
+    m_pContext->setObjectFileInfo(m_pObjFileInfo);
+#else
     // Create new MC context
     m_pContext = new MCContext((const llvm::MCAsmInfo*)m_pAsmInfo, regInfo, m_pObjFileInfo, m_pSrcMgr);
 
-    Triple triple = Triple(GetTargetTriple());
     m_pObjFileInfo->InitMCObjectFileInfo(Triple(GetTargetTriple()), false, *m_pContext);
+#endif
 
     bool is64Bit = GetPointerSize() == 8;
     uint8_t osABI = MCELFObjectTargetWriter::getOSABI(triple.getOS());

--- a/IGC/ElfPackager/main.cpp
+++ b/IGC/ElfPackager/main.cpp
@@ -177,7 +177,11 @@ std::unique_ptr<IGCLLVM::Module> LocalCloneModule(
             }
 
             SmallVector<ReturnInst*, 8> Returns;  // Ignore returns cloned.
+#if LLVM_VERSION_MAJOR >= 13
+            CloneFunctionInto(F, &*I, VMap, CloneFunctionChangeType::DifferentModule, Returns);
+#else
             CloneFunctionInto(F, &*I, VMap, /*ModuleLevelChanges=*/true, Returns);
+#endif
         }
 
         if (I->hasPersonalityFn())

--- a/IGC/LLVM3DBuilder/BuiltinsFrontendDefinitions.hpp
+++ b/IGC/LLVM3DBuilder/BuiltinsFrontendDefinitions.hpp
@@ -5028,7 +5028,7 @@ llvm::Value* LLVM3DBuilder<preserveNames, T, Inserter>::ScalarsToVector(
     IGC_ASSERT(nullptr != resultType);
     llvm::Value* result = llvm::UndefValue::get(resultType);
 
-    for (unsigned i = 0; i < llvm::cast<llvm::VectorType>(resultType)->getNumElements(); i++)
+    for (unsigned i = 0; i < llvm::cast<IGCLLVM::FixedVectorType>(resultType)->getNumElements(); i++)
     {
         IGC_ASSERT(nullptr != scalars[i]);
         IGC_ASSERT(llvm::cast<llvm::VectorType>(resultType)->getElementType() == scalars[i]->getType());

--- a/IGC/VectorCompiler/lib/GenXCodeGen/GenXTargetMachine.h
+++ b/IGC/VectorCompiler/lib/GenXCodeGen/GenXTargetMachine.h
@@ -97,7 +97,11 @@ public:
   bool shouldBuildLookupTables() { return false; }
   unsigned getFlatAddressSpace() { return 4; }
 
+#if LLVM_VERSION_MAJOR >= 13
+  InstructionCost getUserCost(const User *U, ArrayRef<const Value *> Operands
+#else
   int getUserCost(const User *U, ArrayRef<const Value *> Operands
+#endif
 #if LLVM_VERSION_MAJOR >= 11
                   ,
                   TTI::TargetCostKind CostKind

--- a/IGC/WrapperLLVM/include/llvmWrapper/Transforms/Scalar.h
+++ b/IGC/WrapperLLVM/include/llvmWrapper/Transforms/Scalar.h
@@ -26,7 +26,7 @@ namespace IGCLLVM
     {
         return llvm::createLoopUnrollPass(OptLevel, false, Threshold, Count, AllowPartial, Runtime, UpperBound, AllowPeeling);
     }
-#elif LLVM_VERSION_MAJOR >= 9 && LLVM_VERSION_MAJOR <= 12
+#elif LLVM_VERSION_MAJOR >= 9 && LLVM_VERSION_MAJOR <= 13
     inline static llvm::Pass * createLoopUnrollPass(
         int OptLevel = 2, int Threshold = -1, int Count = -1,
         int AllowPartial = -1, int Runtime = -1,

--- a/IGC/common/LLVMUtils.cpp
+++ b/IGC/common/LLVMUtils.cpp
@@ -132,7 +132,11 @@ bool IGCPassManager::isInList(const StringRef& N, const StringRef& List) const
         size_t endPos = List.find_first_of(Separators, startPos);
         size_t len = (endPos != StringRef::npos ? endPos - startPos : endPos);
         StringRef Name = List.substr(startPos, len);
+#if LLVM_VERSION_MAJOR >= 13
+        if (Name.equals_insensitive(N))
+#else
         if (Name.equals_lower(N))
+#endif
         {
             return true;
         }
@@ -149,7 +153,11 @@ bool IGCPassManager::isPrintBefore(Pass* P)
         //                         or pass command args registered in passInfo.
         StringRef  passNameList(IGC_GET_REGKEYSTRING(PrintBefore));
         StringRef PN = P->getPassName();
+#if LLVM_VERSION_MAJOR >= 13
+        if (passNameList.equals_insensitive("all") || isInList(PN, passNameList))
+#else
         if (passNameList.equals_lower("all") || isInList(PN, passNameList))
+#endif
             return true;
 
         // further check passInfo
@@ -173,7 +181,11 @@ bool IGCPassManager::isPrintAfter(Pass* P)
         //                         or pass command args registered in passInfo.
         StringRef  passNameList(IGC_GET_REGKEYSTRING(PrintAfter));
         StringRef PN = P->getPassName();
+#if LLVM_VERSION_MAJOR >= 13
+        if (passNameList.equals_insensitive("all") || isInList(PN, passNameList))
+#else
         if (passNameList.equals_lower("all") || isInList(PN, passNameList))
+#endif
             return true;
 
         // further check passInfo

--- a/visa/iga/IGALibrary/IR/BitSet.hpp
+++ b/visa/iga/IGALibrary/IR/BitSet.hpp
@@ -12,6 +12,8 @@ SPDX-License-Identifier: MIT
 #include "../asserts.hpp"
 #include "common/secure_mem.h"
 
+#include <stdexcept>
+#include <limits>
 #include <algorithm>
 #include <bitset>
 #include <cstdint>


### PR DESCRIPTION
Signed-off-by: Zoltán Böszörményi <zboszor@gmail.com>
Building with LLVM 13 also needs this if `-Werror` is in effect:
```
export CXXFLAGS="-Wno-error=deprecated-declarations"
```
Fixes: #193 