### PR TITLE
IGC: CMakeLists: add project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@
 
 cmake_minimum_required(VERSION 3.13.4 FATAL_ERROR)
 
+project(IGC)
+
 add_subdirectory(IGC)
 
 list(APPEND IGC__IGC_TARGETS "igc_dll")


### PR DESCRIPTION
If project is not added, CMake will warn about it:
No project() command is present. The top-level CMakeLists.txt file
must contain a literal, direct call to the project() command.

Signed-off-by: Conrad Kostecki <conrad@kostecki.com>