### PR TITLE
IGC: CMakeLists: adjust minimum_version

### DIFF
--- a/visa/CMakeLists.txt
+++ b/visa/CMakeLists.txt
@@ -68,7 +68,7 @@ if(WIN32)
   cmake_minimum_required(VERSION 3.1)
   cmake_policy(SET CMP0043 OLD)
 else()
-  cmake_minimum_required(VERSION 2.8)
+  cmake_minimum_required(VERSION 2.8.12)
 endif(WIN32)
 
 # In the case where this is the IGC build we need to add a dummy custom target check_headers

--- a/visa/iga/GEDLibrary/GED_external/CMakeLists.txt
+++ b/visa/iga/GEDLibrary/GED_external/CMakeLists.txt
@@ -10,7 +10,7 @@
 if(WIN32)
     cmake_minimum_required(VERSION 3.1)
 else()
-    cmake_minimum_required(VERSION 2.8)
+    cmake_minimum_required(VERSION 2.8.12)
 endif(WIN32)
 
 project(GEDLibrary)


### PR DESCRIPTION
As CMake warns about possible compatibility problems,
the minimum version should be updated, as it should be compatible.

Otherwise, the warning is printed:
Compatibility with CMake < 2.8.12 will be removed from a future version of CMake.

Signed-off-by: Conrad Kostecki <conrad@kostecki.com>