### PR TITLE
Compile PreprocessSpvir.cpp when compiling UnifyIROCL.cpp

### DIFF
--- a/IGC/DriverInterface/CMakeLists.txt
+++ b/IGC/DriverInterface/CMakeLists.txt
@@ -27,6 +27,7 @@ set(IGC_BUILD__SRC__DriverInterface
     "${CMAKE_CURRENT_SOURCE_DIR}/../AdaptorOCL/OCL/sp/sp_debug.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../AdaptorOCL/OCL/util/BinaryStream.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../AdaptorOCL/UnifyIROCL.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../AdaptorOCL/PreprocessSPVIR.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../AdaptorOCL/MoveStaticAllocas.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../AdaptorOCL/OCL/sp/zebin_builder.cpp"
   )


### PR DESCRIPTION
Just a mild annoyance: PreprocessSPVIR.cpp should be compiled whenever UnifyIROCL.cpp is compiled.
