### PR TITLE
Fix cross-compiling elf_packager

### DIFF
--- a/IGC/ElfPackager/CMakeLists.txt
+++ b/IGC/ElfPackager/CMakeLists.txt
@@ -54,7 +54,7 @@ if(NOT TARGET ${IGC_BUILD__PROJ__ElfPackager})
   if(NOT ANDROID)
     add_custom_command(TARGET ${IGC_BUILD__PROJ__ElfPackager}
                       POST_BUILD
-                      COMMAND $<TARGET_FILE:${IGC_BUILD__PROJ__ElfPackager}> -includeSizet -funcList ${CMAKE_CURRENT_SOURCE_DIR}/function_bin.txt ${IGC_BUILD__BIF_DIR}/OCLBiFImpl.bc ${IGC_BUILD__BIF_DIR}/igdclbif.bin
+                      COMMAND ${IGC_BUILD__PROJ__ElfPackager} -includeSizet -funcList ${CMAKE_CURRENT_SOURCE_DIR}/function_bin.txt ${IGC_BUILD__BIF_DIR}/OCLBiFImpl.bc ${IGC_BUILD__BIF_DIR}/igdclbif.bin
                       )
   endif()
 


### PR DESCRIPTION
This allows CMAKE to wrap the executable with -DCMAKE_CROSSCOMPILING_EMULATOR=...

Signed-off-by: Zoltán Böszörményi <zboszor@gmail.com>