### PR TITLE
lld: copy unwind only when building from source

### DIFF
--- a/external/llvm/llvm_deps.cmake
+++ b/external/llvm/llvm_deps.cmake
@@ -44,12 +44,6 @@ include(llvm_spirv_source_hook)
 # LLD source hook.
 if(IGC_OPTION__LLVM_LLD)
   include(llvm_lld_source_hook)
-  if(NOT EXISTS "${IGC_LLVM_WORKSPACE_SRC}/libunwind/include/mach-o" AND ${IGC_OPTION__LLVM_PREFERRED_VERSION} GREATER_EQUAL "12.0.0")
-    # Need to copy one header from unwind package for LLD (only for building from sources)
-    file(MAKE_DIRECTORY ${IGC_LLVM_WORKSPACE_SRC}/libunwind/include/mach-o)
-    file(COPY ${DEFAULT_IGC_LLVM_SOURCES_DIR}/libunwind/include/mach-o/compact_unwind_encoding.h
-         DESTINATION ${IGC_LLVM_WORKSPACE_SRC}/libunwind/include/mach-o/)
-  endif()
 endif()
 
 # Process LLVM.

--- a/external/llvm/llvm_lld_source_hook.cmake
+++ b/external/llvm/llvm_lld_source_hook.cmake
@@ -47,5 +47,12 @@ if(NOT EXISTS "${IGC_COPIED_LLD_DIR}")
   execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${IGC_OPTION__lld_SOURCES_DIR} ${IGC_COPIED_LLD_DIR})
 endif()
 
+if(NOT EXISTS "${IGC_LLVM_WORKSPACE_SRC}/libunwind/include/mach-o" AND ${IGC_OPTION__LLVM_PREFERRED_VERSION} GREATER_EQUAL "12.0.0")
+  # Need to copy one header from unwind package for LLD (only for building from sources)
+  file(MAKE_DIRECTORY ${IGC_LLVM_WORKSPACE_SRC}/libunwind/include/mach-o)
+  file(COPY ${DEFAULT_IGC_LLVM_SOURCES_DIR}/libunwind/include/mach-o/compact_unwind_encoding.h
+       DESTINATION ${IGC_LLVM_WORKSPACE_SRC}/libunwind/include/mach-o/)
+endif()
+
 # Just register lld as external llvm project.
 register_llvm_external_project(lld ${IGC_COPIED_LLD_DIR})


### PR DESCRIPTION
Currenty, building with a prebuilt `lld` results in:
```
CMake Error at external/llvm/llvm_deps.cmake:50 (file):
  file COPY cannot find
  "/build/intel-graphics-compiler/src/intel-graphics-compiler-igc-1.0.8744/IGC/DEFAULT_IGC_LLVM_SOURCES_DIR-NOTFOUND/libunwind/include/mach-o/compact_unwind_encoding.h":
  No such file or directory.
Call Stack (most recent call first):
  IGC/CMakeLists.txt:1252 (include)
```

I think this code should only be run when building from source as the comment suggest, so I (hopefully) moved it to the right place.