### PR TITLE
IGA: limit non-standard strerror_r to glibc

### DIFF
--- a/visa/iga/IGALibrary/system.cpp
+++ b/visa/iga/IGALibrary/system.cpp
@@ -259,8 +259,13 @@ std::string iga::FormatLastError(unsigned errCode)
         NULL);
     if (errMsg)
         msg = errMsg;
-#else
+#elif defined(__GLIBC__)
     errMsg = strerror_r(errCode, buf, sizeof(buf));
+#else
+    if (strerror_r(errCode, buf, sizeof(buf)))
+        errMsg = nullptr;
+    else
+        errMsg = buf;
 #endif // _WIN32
     if (errMsg == nullptr || errMsg[0] == 0)
         return "???";


### PR DESCRIPTION
Fixes for https://github.com/intel/intel-graphics-compiler/issues/213
Tested via https://github.com/freebsd/freebsd-ports/commit/b2e49cc576b5
