### PR TITLE
Fix github action build failed

### DIFF
--- a/external/llvm/llvm_spirv_source_path.cmake
+++ b/external/llvm/llvm_spirv_source_path.cmake
@@ -12,6 +12,7 @@ list(APPEND IGC_LLVM_SPIRV_PATHS
   ${CMAKE_CURRENT_LIST_DIR}/../../../../SPIRV-LLVM-Translator
   ${CMAKE_CURRENT_LIST_DIR}/../../../llvm-spirv
   ${CMAKE_CURRENT_LIST_DIR}/../../../../llvm-spirv
+  ${CMAKE_CURRENT_LIST_DIR}/../../../llvm-project/llvm/projects/llvm-spirv
   )
 
 find_path(DEFAULT_SPIRV_TRANSLATOR_SOURCE_DIR


### PR DESCRIPTION
The source code of `SPIRV-LLVM-Translator` is cloned by `buildIGC.sh` to
the `../llvm-project/llvm/projects/llvm-spirv` directory, which is the
`${CMAKE_CURRENT_LIST_DIR}/../../../llvm-project/llvm/projects/llvm-spirv`
directory, append this to `IGC_LLVM_SPIRV_PATHS`.