### PR TITLE
Fix compilation error with GCC 12

### DIFF
--- a/IGC/VectorCompiler/lib/GenXCodeGen/GenXLiveness.cpp
+++ b/IGC/VectorCompiler/lib/GenXCodeGen/GenXLiveness.cpp
@@ -587,7 +587,7 @@ void GenXLiveness::replaceValue(SimpleValue OldVal, SimpleValue NewVal)
  */
 LiveRange *GenXLiveness::getOrCreateLiveRange(SimpleValue V)
 {
-  auto [i, isInserted] = LiveRangeMap.insert(LiveRangeMap_t::value_type(V, 0));
+  auto [i, isInserted] = LiveRangeMap.emplace(V, nullptr);
   LLVM_DEBUG(dbgs() << "getOrCreateLiveRange for SimpleValue: " << V << " "
                     << (isInserted ? "Inserted" : "Not inserted") << "\n");
   LiveRange *LR = i->second;


### PR DESCRIPTION
This hits a bug in unreleased GCC 12 snapshots, due to an ambiguous
std::pair constructor. It can be easily avoided and improve the code at
the same time, by using nullptr for the pointer, and using emplace to
avoid an unnecessary temporary.