### PR TITLE
External: SPIRV-Tools: Look for shared pkg-config

### DIFF
--- a/external/SPIRV-Tools/CMakeLists.txt
+++ b/external/SPIRV-Tools/CMakeLists.txt
@@ -33,8 +33,8 @@ if(IGC_OPTION__VC_INTRINSICS_MODE STREQUAL PREBUILDS_MODE_NAME)
  set(IGC_BUILD__SPIRV-Tools_DIR "${SPIRV-Tools_ROOT_DIR}")
 
  set(INCLUDE_DIRS_LIST "${SPIRV-Tools_ROOT_DIR}/include" "${SPIRV-Headers_INCLUDE_DIR}")
- set_target_properties(SPIRV-Tools-static PROPERTIES INCLUDE_DIRECTORIES "${INCLUDE_DIRS_LIST}")
- set(IGC_BUILD__PROJ__SPIRV-Tools SPIRV-Tools-static)
+ set_target_properties(SPIRV-Tools PROPERTIES INCLUDE_DIRECTORIES "${INCLUDE_DIRS_LIST}")
+ set(IGC_BUILD__PROJ__SPIRV-Tools SPIRV-Tools)
 
 else() #By default use build from sources
  message(STATUS "[SPIRV-Tools] : IGC_OPTION__VC_INTRINSICS_MODE set to Source")


### PR DESCRIPTION
Fedora builds spirv-tools as a shared lib: https://src.fedoraproject.org/rpms/spirv-tools/blob/rawhide/f/spirv-tools.spec#_57
It *seems* that arch does the same: https://github.com/archlinux/svntogit-packages/blob/packages/spirv-tools/trunk/PKGBUILD#L27

The build, linking and some basic sanity checks seem to work well with igc built this way, but I am really not sure if there aren't any unwanted implications of this change.