### PR TITLE
External lldELF requires zlib for linking

### DIFF
--- a/IGC/cmake/igc_find_liblldELF.cmake
+++ b/IGC/cmake/igc_find_liblldELF.cmake
@@ -149,6 +149,11 @@ elseif(IGC_BUILD__LLVM_PREBUILDS)
     ${LLD_ELF_LLVM_DEPS}
     lldCommon)
 
+  if(LLVM_ENABLE_ZLIB)
+    find_package(ZLIB)
+    target_link_libraries(lldELF INTERFACE ZLIB::ZLIB)
+  endif()
+
   if(NOT DEFINED IGC_OPTION__LLDELF_H_DIR)
     set(IGC_OPTION__LLDELF_H_DIR ${LLVM_ROOT})
   endif()


### PR DESCRIPTION
Without this patch, our builds end up with:
```
/usr/bin/ld: /usr/lib/liblldELF.a(OutputSections.cpp.o): in function `deflateShard(llvm::ArrayRef<unsigned char>, int, int)':
(.text._ZL12deflateShardN4llvm8ArrayRefIhEEii+0x6a): undefined reference to `deflateInit2_'
/usr/bin/ld: (.text._ZL12deflateShardN4llvm8ArrayRefIhEEii+0xd1): undefined reference to `deflate'
/usr/bin/ld: (.text._ZL12deflateShardN4llvm8ArrayRefIhEEii+0x119): undefined reference to `deflateEnd'
/usr/bin/ld: /usr/lib/liblldELF.a(OutputSections.cpp.o): in function `void llvm::function_ref<void (unsigned long)>::callback_fn<lld::elf::OutputSection::maybeCompress<llvm::object::ELFType<(llvm::support::endianness)1, false> >()::{lambda(unsigned long)#1}>(long, unsigned long)':
(.text._ZN4llvm12function_refIFvmEE11callback_fnIZN3lld3elf13OutputSection13maybeCompressINS_6object7ELFTypeILNS_7support10endiannessE1ELb0EEEEEvvEUlmE_EEvlm[_ZN4llvm12function_refIFvmEE11callback_fnIZN3lld3elf13OutputSection13maybeCompressINS_6object7ELFTypeILNS_7support10endiannessE1ELb0EEEEEvvEUlmE_EEvlm]+0xed): undefined reference to `adler32'
/usr/bin/ld: /usr/lib/liblldELF.a(OutputSections.cpp.o): in function `void llvm::function_ref<void (unsigned long)>::callback_fn<lld::elf::OutputSection::maybeCompress<llvm::object::ELFType<(llvm::support::endianness)0, false> >()::{lambda(unsigned long)#1}>(long, unsigned long)':
(.text._ZN4llvm12function_refIFvmEE11callback_fnIZN3lld3elf13OutputSection13maybeCompressINS_6object7ELFTypeILNS_7support10endiannessE0ELb0EEEEEvvEUlmE_EEvlm[_ZN4llvm12function_refIFvmEE11callback_fnIZN3lld3elf13OutputSection13maybeCompressINS_6object7ELFTypeILNS_7support10endiannessE0ELb0EEEEEvvEUlmE_EEvlm]+0xed): undefined reference to `adler32'
/usr/bin/ld: /usr/lib/liblldELF.a(OutputSections.cpp.o): in function `void llvm::function_ref<void (unsigned long)>::callback_fn<lld::elf::OutputSection::maybeCompress<llvm::object::ELFType<(llvm::support::endianness)0, true> >()::{lambda(unsigned long)#1}>(long, unsigned long)':
(.text._ZN4llvm12function_refIFvmEE11callback_fnIZN3lld3elf13OutputSection13maybeCompressINS_6object7ELFTypeILNS_7support10endiannessE0ELb1EEEEEvvEUlmE_EEvlm[_ZN4llvm12function_refIFvmEE11callback_fnIZN3lld3elf13OutputSection13maybeCompressINS_6object7ELFTypeILNS_7support10endiannessE0ELb1EEEEEvvEUlmE_EEvlm]+0xed): undefined reference to `adler32'
/usr/bin/ld: /usr/lib/liblldELF.a(OutputSections.cpp.o): in function `void llvm::function_ref<void (unsigned long)>::callback_fn<lld::elf::OutputSection::maybeCompress<llvm::object::ELFType<(llvm::support::endianness)1, true> >()::{lambda(unsigned long)#1}>(long, unsigned long)':
(.text._ZN4llvm12function_refIFvmEE11callback_fnIZN3lld3elf13OutputSection13maybeCompressINS_6object7ELFTypeILNS_7support10endiannessE1ELb1EEEEEvvEUlmE_EEvlm[_ZN4llvm12function_refIFvmEE11callback_fnIZN3lld3elf13OutputSection13maybeCompressINS_6object7ELFTypeILNS_7support10endiannessE1ELb1EEEEEvvEUlmE_EEvlm]+0xed): undefined reference to `adler32'
/usr/bin/ld: /usr/lib/liblldELF.a(OutputSections.cpp.o): in function `void lld::elf::OutputSection::maybeCompress<llvm::object::ELFType<(llvm::support::endianness)1, false> >()':
(.text._ZN3lld3elf13OutputSection13maybeCompressIN4llvm6object7ELFTypeILNS3_7support10endiannessE1ELb0EEEEEvv[_ZN3lld3elf13OutputSection13maybeCompressIN4llvm6object7ELFTypeILNS3_7support10endiannessE1ELb0EEEEEvv]+0x3c3): undefined reference to `adler32_combine'
/usr/bin/ld: /usr/lib/liblldELF.a(OutputSections.cpp.o): in function `void lld::elf::OutputSection::maybeCompress<llvm::object::ELFType<(llvm::support::endianness)1, true> >()':
(.text._ZN3lld3elf13OutputSection13maybeCompressIN4llvm6object7ELFTypeILNS3_7support10endiannessE1ELb1EEEEEvv[_ZN3lld3elf13OutputSection13maybeCompressIN4llvm6object7ELFTypeILNS3_7support10endiannessE1ELb1EEEEEvv]+0x3c3): undefined reference to `adler32_combine'
/usr/bin/ld: /usr/lib/liblldELF.a(OutputSections.cpp.o): in function `void lld::elf::OutputSection::maybeCompress<llvm::object::ELFType<(llvm::support::endianness)0, true> >()':
(.text._ZN3lld3elf13OutputSection13maybeCompressIN4llvm6object7ELFTypeILNS3_7support10endiannessE0ELb1EEEEEvv[_ZN3lld3elf13OutputSection13maybeCompressIN4llvm6object7ELFTypeILNS3_7support10endiannessE0ELb1EEEEEvv]+0x3c3): undefined reference to `adler32_combine'
/usr/bin/ld: /usr/lib/liblldELF.a(OutputSections.cpp.o): in function `void lld::elf::OutputSection::maybeCompress<llvm::object::ELFType<(llvm::support::endianness)0, false> >()':
(.text._ZN3lld3elf13OutputSection13maybeCompressIN4llvm6object7ELFTypeILNS3_7support10endiannessE0ELb0EEEEEvv[_ZN3lld3elf13OutputSection13maybeCompressIN4llvm6object7ELFTypeILNS3_7support10endiannessE0ELb0EEEEEvv]+0x3c3): undefined reference to `adler32_combine'
```