### PR TITLE
 Changing the order in which ReplaceUnsupportedIntrinsics pass runs

### DIFF
--- a/IGC/AdaptorOCL/DriverInfoOCL.hpp
+++ b/IGC/AdaptorOCL/DriverInfoOCL.hpp
@@ -75,6 +75,7 @@ namespace TC
         bool SupportInlineAssembly() const override { return true; }
         /// Enables the use of inline data on XeHP_SDV+
         virtual bool UseInlineData() const override { return true; }
+        bool supportsAutoGRFSelection() const override { return true; }
     };
 
 }//namespace TC


### PR DESCRIPTION
Instruction combining may merge instruction back into unsupported intrinsics.
Therefore last Replace Unsupported Intrinsics Pass must be after last
Instruction combining pass.
Replace Unsupported Intrinsics Pass may generate new 64 bit operations.
Therefore last 64bit emulation pass must be after the last Replace Unsupported Intrinsics Pass.