### PR TITLE
SPIRVutil: Include cstdint to fix GCC 13 build

### DIFF
--- a/IGC/AdaptorOCL/SPIRV/libSPIRV/SPIRVUtil.h
+++ b/IGC/AdaptorOCL/SPIRV/libSPIRV/SPIRVUtil.h
@@ -49,6 +49,7 @@ THE SOFTWARE.
 #define SPIRVUTIL_H_
 
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <limits>
 #include <map>


### PR DESCRIPTION
Makes igc buildable with GCC 13.