### PR TITLE
Add mako dependency

### DIFF
--- a/documentation/build_ubuntu.md
+++ b/documentation/build_ubuntu.md
@@ -15,7 +15,8 @@ SPDX-License-Identifier: MIT
 Building IGC needs flex, bison, libz and cmake version at least 3.13.4. You can install required packages on Ubuntu using this command:
 
 ```shell
-$ sudo apt-get install flex bison libz-dev cmake libc6 libstdc++6
+$ sudo apt-get install flex bison libz-dev cmake libc6 libstdc++6 python3-pip
+$ sudo python3 -m pip install mako
 ```
 
 Some of the incoming git operations will try to download and apply patches. For this purpose it is necessary to setup git credentials if they are not already in the git configuration:


### PR DESCRIPTION
Without this, the build fails with following error:

```
Consolidate compiler generated dependencies of target obj.clangFormat                                                                                                                                              
Consolidate compiler generated dependencies of target obj.clangToolingInclusions                                                                                                                                   
Traceback (most recent call last):                                                                                                                                                                                 
  File "/home/sasank/code/igc_workspace/igc/IGC/GenISAIntrinsics/generator/generate_intrinsic_files.py", line 11, in <module>                                                                                      
    from Intrinsic_utils import file_path, dir_path                                                                                                                                                                
  File "/home/sasank/code/igc_workspace/igc/IGC/GenISAIntrinsics/generator/Intrinsic_utils.py", line 14, in <module>                                                                                               
    from mako.template import Template                                                                                                                                                                             
ModuleNotFoundError: No module named 'mako'                                                                                                                                                                        
Consolidate compiler generated dependencies of target obj.clangToolingCore                                                                                                                                         
Consolidate compiler generated dependencies of target obj.clangRewrite
Consolidate compiler generated dependencies of target obj.clangCrossTU
make[2]: *** [IGC/GenISAIntrinsics/CMakeFiles/GenISAIntrinsics.dir/build.make:84: IGC/Release/GenIntrinsicDescription.h] Error 1
make[1]: *** [CMakeFiles/Makefile2:33415: IGC/GenISAIntrinsics/CMakeFiles/GenISAIntrinsics.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

So added instructions to install mako into docs.