### PR TITLE
fixed invalid use of template keyword

### DIFF
--- a/IGC/AdaptorOCL/cif/cif/export/registry.h
+++ b/IGC/AdaptorOCL/cif/cif/export/registry.h
@@ -46,7 +46,7 @@ struct EntryPointInterface : EntryPointInterfaceBase {
     }
 
     ICIF * Create(Version_t version, ICIF * parent) const override{
-        return CIF::InterfaceCreator<Interface>::template CreateInterfaceVer(version, version, parent);
+        return CIF::InterfaceCreator<Interface>::CreateInterfaceVer(version, version, parent);
     }
 
     InterfaceId_t GetFirstIncompatible(CIF::CompatibilityDataHandle handle) const override{


### PR DESCRIPTION
Had a compilation issue in `intel-graphics-compiler-2.5.6` release related to how a template parameter is used. The compilation error happens with `clang (19.1.1)`. This patch manages that issue.