### PR TITLE
Raise minimum CMake version to 3.10

### DIFF
--- a/external/SPIRV-Tools/CMakeLists.txt
+++ b/external/SPIRV-Tools/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 #============================ end_copyright_notice =============================
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 message(STATUS "============================ SPIRV-Tools project ============================")
 

--- a/visa/CMakeLists.txt
+++ b/visa/CMakeLists.txt
@@ -74,12 +74,7 @@ if (WIN32 OR UNIX)
   add_subdirectory(iga/IGAExe)
 endif (WIN32 OR UNIX)
 
-if(WIN32)
-  cmake_minimum_required(VERSION 3.1)
-  cmake_policy(SET CMP0043 OLD)
-else()
-  cmake_minimum_required(VERSION 2.8.12)
-endif(WIN32)
+cmake_minimum_required(VERSION 3.10)
 
 # In the case where this is the IGC build we need to add a dummy custom target check_headers
 add_custom_target(check_headers)

--- a/visa/iga/GEDLibrary/GED_external/CMakeLists.txt
+++ b/visa/iga/GEDLibrary/GED_external/CMakeLists.txt
@@ -7,11 +7,7 @@
 #============================ end_copyright_notice =============================
 
 # GEDLibrary/GED
-if(WIN32)
-    cmake_minimum_required(VERSION 3.1)
-else()
-    cmake_minimum_required(VERSION 2.8.12)
-endif(WIN32)
+cmake_minimum_required(VERSION 3.10)
 
 project(GEDLibrary)
 


### PR DESCRIPTION
For compatibility with CMake 4.0, which also removes CMP0043 OLD - there are no uses of `COMPILE_DEFINITIONS_<CONFIG>`.

---

I've used this on Linux with CMake 4.0.2.
