### PR TITLE
Declare blank CDECLATTRIBUTE for riscv

### DIFF
--- a/IGC/common/ShaderOverride.cpp
+++ b/IGC/common/ShaderOverride.cpp
@@ -50,7 +50,7 @@ static void * GetProcAddress(
 #if defined(WIN32)
 #define CDECLATTRIBUTE __cdecl
 #elif __GNUC__
-#if defined(__x86_64__) || defined(__ARM_ARCH)
+#if defined(__x86_64__) || defined(__ARM_ARCH) || defined(__riscv)
 #define CDECLATTRIBUTE
 #else
 #define CDECLATTRIBUTE                 __attribute__((__cdecl__))

--- a/visa/iga/IGALibrary/api/igad.h
+++ b/visa/iga/IGALibrary/api/igad.h
@@ -17,7 +17,7 @@ SPDX-License-Identifier: MIT
 #elif __GNUC__
 #ifdef __x86_64__
 #define CDECLATTRIBUTE
-#elif defined(__ARM_ARCH)
+#elif defined(__ARM_ARCH) || defined(__riscv)
 #define CDECLATTRIBUTE
 #else
 #define CDECLATTRIBUTE __attribute__((__cdecl__))


### PR DESCRIPTION
Fixes compile error caused by `-Werror` on riscv64.

```text
/build/intel-graphics-compiler/src/intel-graphics-compiler-2.12.5/visa/iga/IGALibrary/api/igad.h:31:57: error: ‘cdecl’ attribute directive ignored [-Werror=attributes]
  31 | typedef const char *(CDECLATTRIBUTE *pIGAVersionString)();
```