### PR TITLE
fixed missing overload on musl based systems

### DIFF
--- a/visa/iga/IGALibrary/system.cpp
+++ b/visa/iga/IGALibrary/system.cpp
@@ -215,6 +215,10 @@ unsigned iga::LastError() {
 #endif // _WIN32
 }
 
+[[maybe_unused]]
+static void add_strerror_r_to_error(char *errMsg, int strerror_r_return_value) {
+}
+
 static void add_strerror_r_to_error(char *errMsg,
                                     char *strerror_r_return_value) {
   errMsg = strerror_r_return_value;


### PR DESCRIPTION
This overload was removed in f0962ad863a85c4cfc417e57aa046dc73a79e193 likely due to the author mistakenly believing it was unused. Without the overload there is a compile error on musl based systems.

Fixes: https://github.com/intel/intel-graphics-compiler/issues/373