### PR TITLE
Adding 2 minor patch files for building latest IGC based on llvm 16 with GCC 15.2

### DIFF
--- a/external/llvm/releases/16.0.0/patches_external/add_missing_cstdint_include_gcc15.patch
+++ b/external/llvm/releases/16.0.0/patches_external/add_missing_cstdint_include_gcc15.patch
@@ -1,0 +1,27 @@
+/*========================== begin_copyright_notice ============================
+
+Copyright (C) 2025 Intel Corporation
+
+SPDX-License-Identifier: MIT
+
+============================= end_copyright_notice ===========================*/
+
+/*========================== begin_copyright_notice ============================
+
+Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+See https://llvm.org/LICENSE.txt for license information.
+SPDX-License-Identifier: Apache-2.0 with LLVM-exception
+
+============================= end_copyright_notice ===========================*/
+diff --git a/llvm/include/llvm/ADT/SmallVector.h b/llvm/include/llvm/ADT/SmallVector.h
+index e34702bdbb3c..08fa2765a1c2 100644
+--- a/llvm/include/llvm/ADT/SmallVector.h
++++ b/llvm/include/llvm/ADT/SmallVector.h
+@@ -21,6 +21,7 @@
+ #include <cstddef>
+ #include <cstdlib>
+ #include <cstring>
++#include <cstdint>
+ #include <functional>
+ #include <initializer_list>
+ #include <iterator>

--- a/external/llvm/releases/16.0.0/patches_external/change_ciso646_to_version.patch
+++ b/external/llvm/releases/16.0.0/patches_external/change_ciso646_to_version.patch
@@ -1,0 +1,28 @@
+/*========================== begin_copyright_notice ============================
+
+Copyright (C) 2025 Intel Corporation
+
+SPDX-License-Identifier: MIT
+
+============================= end_copyright_notice ===========================*/
+
+/*========================== begin_copyright_notice ============================
+
+Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+See https://llvm.org/LICENSE.txt for license information.
+SPDX-License-Identifier: Apache-2.0 with LLVM-exception
+
+============================= end_copyright_notice ===========================*/
+diff --git a/llvm/include/llvm/Support/Threading.h b/llvm/include/llvm/Support/Threading.h
+index ba6c531ab4db..78aa5e7be5b5 100644
+--- a/llvm/include/llvm/Support/Threading.h
++++ b/llvm/include/llvm/Support/Threading.h
+@@ -18,7 +18,7 @@
+ #include "llvm/ADT/StringRef.h"
+ #include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX
+ #include "llvm/Support/Compiler.h"
+-#include <ciso646> // So we can check the C++ standard lib macros.
++#include <version> // So we can check the C++ standard lib macros.
+ #include <optional>
+
+ #if defined(_MSC_VER)


### PR DESCRIPTION
One patchfile was not migrated from llvm 15 (stdint in smallvector incl)
One patchfile changes <ciso646> include to <version> as <ciso646> is deprecated.