### PR TITLE
fix: make BiFManager builtin-index hash independent of the C++ standard library

### DIFF
--- a/IGC/BiFManager/BiFManagerCommon.cpp
+++ b/IGC/BiFManager/BiFManagerCommon.cpp
@@ -12,6 +12,7 @@ SPDX-License-Identifier: MIT
 
 #include "BiFManagerCommon.hpp"
 #include <Probe/Assertion.h>
+#include <cstdint>
 #include <map>
 
 using namespace std;
@@ -23,7 +24,20 @@ BiFManagerCommon::BiFManagerCommon(LLVMContext &Context) : Context(Context) {}
 
 BiFManagerCommon::~BiFManagerCommon() {}
 
-size_t BiFManagerCommon::getHash(const std::string &FlagName) { return std::hash<std::string>{}(FlagName); }
+// Stdlib-independent 64-bit FNV-1a. std::hash<std::string> is implementation-
+// defined and differs between libstdc++ (host BiFManager-bin) and libc++ (cross
+// libigc.so runtime): the host tool bakes case <hash>ULL labels into OCLBiFImpl.h
+// while the runtime recomputes a different value, so every builtin lookup missed
+// and no BiF bodies were linked (all __spirv_* undefined). A fixed hash makes the
+// generated case labels and the runtime lookups agree regardless of stdlib.
+size_t BiFManagerCommon::getHash(const std::string &FlagName) {
+  uint64_t h = 1469598103934665603ULL;
+  for (unsigned char c : FlagName) {
+    h ^= static_cast<uint64_t>(c);
+    h *= 1099511628211ULL;
+  }
+  return static_cast<size_t>(h);
+}
 
 CollectBuiltinsPass::CollectBuiltinsPass(TFunctionsVec &neededBuiltinsFunc,
                                          const std::function<bool(llvm::Function *)> &predicate)


### PR DESCRIPTION
## Problem

`BiFManagerCommon::getHash()` uses `std::hash<std::string>`, whose result is
implementation-defined and differs across C++ standard libraries. `BiFManager-bin`
bakes the hashes of builtin names into the generated `OCLBiFImpl.h` as
`case <hash>ULL:` labels at build time, and `BiFManagerHandler::GetDepList`
recomputes `getHash()` for each referenced function at run time to find its section.

When the host `BiFManager-bin` and the `libigc` runtime are linked against
**different** standard libraries -- the usual situation when cross-compiling IGC for
Android (a libstdc++ host tool generating the header while `libigc` is built with
libc++) -- the generated `case` labels and the runtime lookups disagree for every
name. The switch always falls through to `{-1}`, `findAllBuiltins()` collects
nothing, `LinkBiF()` links no built-in bodies, and **every** `__spirv_*` reference is
reported `undefined reference to ...` -> backend compiler failure
(`CL_BUILD_PROGRAM_FAILURE`). Native single-stdlib builds are unaffected, which is why
this only surfaces in heterogeneous-stdlib / cross builds.

## Fix

Use a fixed 64-bit FNV-1a hash so the generated labels and the runtime lookups always
agree regardless of the C++ standard library. `getHash()` is defined once in
`BiFManagerCommon` and compiled into both the host tool and the runtime.

## Validation

Reproduced cross-compiling IGC (LLVM 17.0.6) for Android x86_64: host `BiFManager-bin`
linked against libstdc++, `libigc.so` against libc++. Before this patch, `ocloc compile`
of any kernel using a builtin failed with
`undefined reference to _Z33__spirv_BuiltInGlobalInvocationIdi`. Binary proof: the
libstdc++ hash of that symbol appeared as an immediate inside `libigc.so` while the
libc++ value the runtime actually computes appeared 0 times. After this patch the
FNV-1a value matches on both sides, `findAllBuiltins` collects the builtins, `ocloc`
reports `Build succeeded.`, and OpenVINO GPU inference runs end to end.