### PR TITLE
Fully initialize struct BiFDataRecord

### DIFF
--- a/IGC/BiFManager/BiFManagerCommon.hpp
+++ b/IGC/BiFManager/BiFManagerCommon.hpp
@@ -46,6 +46,8 @@ public:
 struct BiFDataRecord {
   // Section ID
   BiFSectionID ID;
+  // Explicit padding to initialize for reproducible builds
+  int32_t padding;
   // Beginning of section in the stream
   int64_t bufferStart;
   // Size of the section in the stream
@@ -53,6 +55,7 @@ struct BiFDataRecord {
 
   BiFDataRecord(BiFSectionID ID, int64_t bufferStart, int64_t bufferSize) {
     this->ID = ID;
+    this->padding = 0;
     this->bufferStart = bufferStart;
     this->bufferSize = bufferSize;
   }


### PR DESCRIPTION
Fully initialize `struct BiFDataRecord` for reproducible builds.
Without this patch, 4 bytes were left uninitialized and [ASLR](https://github.com/bmwiedemann/theunreproduciblepackage/tree/master/aslr) caused it to have random content.

See https://reproducible-builds.org for why this matters.

Fixes #359

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).