### PR TITLE
FixAddrSpaceCast: place lowered PHI loads on their incoming edge

### DIFF
--- a/IGC/Compiler/CISACodeGen/FixAddrSpaceCast.cpp
+++ b/IGC/Compiler/CISACodeGen/FixAddrSpaceCast.cpp
@@ -130,10 +130,16 @@ static void lowerLoadsfromPHI(PHINode *PHI) {
     auto *LoadSource = cast<Instruction>(Incoming);
     auto *AddrSpaceCast = dyn_cast<AddrSpaceCastInst>(Incoming);
 
+    // Insert the per-edge cast/load at the incoming block's terminator, not at the
+    // incoming pointer's definition: the definition may merely dominate the incoming
+    // block (e.g. a cast hoisted to a loop preheader) or be followed by stores to the
+    // loaded location, so a load anchored there observes the wrong memory state. SSA
+    // guarantees the incoming value dominates the terminator, so this is always legal.
+    IRBuilder<> Builder(PHI->getIncomingBlock(Incoming)->getTerminator());
+
     for (auto *I : InsertChain) {
 
       if (AddrSpaceCast) {
-        IRBuilder<> Builder(LoadSource);
         if (isa<BitCastInst>(I)) {
           auto *NewBitcast =
               Builder.CreateBitCast(AddrSpaceCast->getOperand(0),
@@ -156,7 +162,7 @@ static void lowerLoadsfromPHI(PHINode *PHI) {
 
       Instruction *NewInst = I->clone();
       NewInst->setOperand(0, LoadSource);
-      NewInst->insertAfter(LoadSource);
+      Builder.Insert(NewInst);
       LoadSource = NewInst;
       if (isa<LoadInst>(NewInst)) {
         NewLoads.insert({NewInst, PHI->getIncomingBlock(Incoming)});

--- a/IGC/Compiler/tests/DebugInfo/FixAddrSpaceCast/lowerLoadsDifferentIncomingAndParent.ll
+++ b/IGC/Compiler/tests/DebugInfo/FixAddrSpaceCast/lowerLoadsDifferentIncomingAndParent.ll
@@ -14,7 +14,9 @@
 ; FixAddrSpaceCast
 ; ------------------------------------------------
 ; Test checks if, in case that incoming Phi value has different parent then incoming block, it is correctly
-; handled and new Phi is created correctly.
+; handled and new Phi is created correctly. The lowered load must land in the incoming block
+; (%cond.between), not in the block that defines the addrspacecast (%cond.false3459), so that it keeps
+; observing the memory state seen on that edge.
 ; ------------------------------------------------
 
 ; CHECK-LABEL: cond.true3442:
@@ -23,9 +25,12 @@
 ; CHECK: br label %cond.end3465
 
 ; CHECK-LABEL: cond.false3459
+; CHECK-NEXT:  br label %cond.between
+
+; CHECK-LABEL: cond.between:
 ; CHECK:  [[T3:%.*]] = bitcast i8 addrspace(3)* %arrayidx3464 to i32 addrspace(3)*
 ; CHECK:  [[T4:%.*]] = load i32, i32 addrspace(3)* [[T3]], align 4
-; CHECK:  br label %cond.between
+; CHECK:  br label %cond.end3465
 
 ; CHECK-LABEL: cond.end3465:
 ; CHECK: [[T5:%.*]] = phi i32 [ [[T2]], %cond.true3442 ], [ [[T4]], %cond.between ]

--- a/IGC/Compiler/tests/DebugInfo/FixAddrSpaceCast/lowerLoadsPhiEdgePlacement.ll
+++ b/IGC/Compiler/tests/DebugInfo/FixAddrSpaceCast/lowerLoadsPhiEdgePlacement.ll
@@ -1,0 +1,123 @@
+;=========================== begin_copyright_notice ============================
+;
+; Copyright (C) 2025 Intel Corporation
+;
+; SPDX-License-Identifier: MIT
+;
+;============================ end_copyright_notice =============================
+;
+; RUN: igc_opt --opaque-pointers --igc-addrspacecast-fix -S %s -o %t.ll
+; RUN: FileCheck %s --input-file=%t.ll
+; ------------------------------------------------
+; FixAddrSpaceCast
+; ------------------------------------------------
+; When a load from a generic PHI is lowered into the incoming blocks, every new
+; load has to observe the same memory state as the original load did. That means
+; it must be placed at the end of the PHI's incoming block, not next to the
+; definition of the incoming addrspacecast/GEP. The definition may live in a
+; block that dominates the incoming block (for instance outside of the loop the
+; PHI belongs to), or it may be followed by stores to the very location being
+; loaded, in which case anchoring the new load at the definition silently hoists
+; it above those stores.
+; ------------------------------------------------
+
+@slm = internal addrspace(3) global [64 x i64] zeroinitializer, align 8
+
+; A three-edge generic PHI: two Workgroup(3) edges and one Function(0) edge.
+; The Function-side addrspacecast is defined in the loop preheader, while the
+; accumulator it points at is written on every iteration in %latch. Reloading it
+; anywhere but in %fallback reads a stale (here: uninitialized) value.
+
+; CHECK-LABEL: @test_phi_edge_placement(
+; CHECK:       entry:
+; CHECK-NOT:     load
+; CHECK:         br label %loop
+
+; CHECK-LABEL: loop:
+; CHECK:         [[SLM1:%.*]] = load i64, ptr addrspace(3) %slm.gep
+; CHECK-NEXT:    br i1 %c0, label %latch, label %check
+
+; CHECK-LABEL: check:
+; CHECK:         [[SLM2:%.*]] = load i64, ptr addrspace(3) %slm.gep
+; CHECK-NEXT:    br i1 %c1, label %latch, label %fallback
+
+; CHECK-LABEL: fallback:
+; CHECK-NEXT:    [[PRIV:%.*]] = load i64, ptr %acc
+; CHECK-NEXT:    br label %latch
+
+; CHECK-LABEL: latch:
+; CHECK-NEXT:    [[MERGE:%.*]] = phi i64 [ [[SLM1]], %loop ], [ [[SLM2]], %check ], [ [[PRIV]], %fallback ]
+; CHECK-NEXT:    store i64 [[MERGE]], ptr %acc
+
+define spir_kernel void @test_phi_edge_placement(ptr addrspace(1) %out, i64 %n) #0 {
+entry:
+  %acc = alloca i64, align 8
+  %acc.gas = addrspacecast ptr %acc to ptr addrspace(4)
+  store i64 0, ptr %acc, align 8
+  br label %loop
+
+loop:                                             ; preds = %latch, %entry
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %latch ]
+  %slm.gep = getelementptr inbounds i64, ptr addrspace(3) @slm, i64 %iv
+  %slm.gas = addrspacecast ptr addrspace(3) %slm.gep to ptr addrspace(4)
+  %c0 = icmp eq i64 %iv, 3
+  br i1 %c0, label %latch, label %check
+
+check:                                            ; preds = %loop
+  %c1 = icmp eq i64 %iv, 5
+  br i1 %c1, label %latch, label %fallback
+
+fallback:                                         ; preds = %check
+  br label %latch
+
+latch:                                            ; preds = %fallback, %check, %loop
+  %sel = phi ptr addrspace(4) [ %slm.gas, %loop ], [ %slm.gas, %check ], [ %acc.gas, %fallback ]
+  %ld = load i64, ptr addrspace(4) %sel, align 8
+  store i64 %ld, ptr %acc, align 8
+  %iv.next = add i64 %iv, 1
+  %more = icmp ult i64 %iv.next, %n
+  br i1 %more, label %loop, label %exit
+
+exit:                                             ; preds = %latch
+  %res = load i64, ptr %acc, align 8
+  store i64 %res, ptr addrspace(1) %out, align 8
+  ret void
+}
+
+; The lowered load must not be hoisted above a store that the original load was
+; ordered after.
+
+; CHECK-LABEL: @test_no_hoist_above_store(
+; CHECK-LABEL: true.bb:
+; CHECK:         [[GLB:%.*]] = load i32, ptr addrspace(4) %gep.res
+; CHECK-NEXT:    br label %merge
+
+; CHECK-LABEL: false.bb:
+; CHECK:         store i32 0, ptr addrspace(4) %addr.res
+; CHECK-NEXT:    [[LOC:%.*]] = load i32, ptr addrspace(3) %p
+; CHECK-NEXT:    br label %merge
+
+; CHECK-LABEL: merge:
+; CHECK-NEXT:    [[SEL:%.*]] = phi i32 [ [[GLB]], %true.bb ], [ [[LOC]], %false.bb ]
+; CHECK-NEXT:    ret i32 [[SEL]]
+
+define i32 @test_no_hoist_above_store(ptr addrspace(3) %p, ptr addrspace(4) %g, i1 %c) #0 {
+entry:
+  br i1 %c, label %true.bb, label %false.bb
+
+true.bb:                                          ; preds = %entry
+  %gep.res = getelementptr inbounds i8, ptr addrspace(4) %g, i64 16
+  br label %merge
+
+false.bb:                                         ; preds = %entry
+  %addr.res = addrspacecast ptr addrspace(3) %p to ptr addrspace(4)
+  store i32 0, ptr addrspace(4) %addr.res, align 4
+  br label %merge
+
+merge:                                            ; preds = %false.bb, %true.bb
+  %sel = phi ptr addrspace(4) [ %gep.res, %true.bb ], [ %addr.res, %false.bb ]
+  %v = load i32, ptr addrspace(4) %sel, align 4
+  ret i32 %v
+}
+
+attributes #0 = { noinline nounwind }


### PR DESCRIPTION
`lowerLoadsfromPHI()` anchors each per-edge load at the definition of the incoming pointer (`FixAddrSpaceCast.cpp:136` and `:159`) instead of in the PHI's incoming block. The definition only has to dominate the incoming block, so the load can be emitted in an earlier block, ahead of stores the original load was ordered after.

Input:

```llvm
false.bb:
  %addr.res = addrspacecast ptr addrspace(3) %p to ptr addrspace(4)
  store i32 0, ptr addrspace(4) %addr.res, align 4
  br label %merge

merge:
  %sel = phi ptr addrspace(4) [ %gep.res, %true.bb ], [ %addr.res, %false.bb ]
  %v = load i32, ptr addrspace(4) %sel, align 4
```

The store writes through `%addr.res`, which is `%p` relabelled, so `%v` has to read what the store wrote.

Before, the lowered load is hoisted above that store and reads stale memory:

```diff
 false.bb:
-  %1 = load i32, ptr addrspace(3) %p, align 4
   %addr.res = addrspacecast ptr addrspace(3) %p to ptr addrspace(4)
   store i32 0, ptr addrspace(4) %addr.res, align 4
   br label %merge
```

After:

```diff
 false.bb:
   %addr.res = addrspacecast ptr addrspace(3) %p to ptr addrspace(4)
   store i32 0, ptr addrspace(4) %addr.res, align 4
+  %1 = load i32, ptr addrspace(3) %p, align 4
   br label %merge
```

Inserting at the incoming block's terminator is always legal: SSA guarantees the incoming value dominates it.

`lowerLoadsDifferentIncomingAndParent.ll` is updated because it covers exactly this shape. `%addr.res` is defined in `%cond.false3459` while the PHI's incoming block is `%cond.between`, and the load now lands in the latter. That file is `UNSUPPORTED: llvm-17-plus`, so I could not execute it here; I ran the same function in opaque-pointer form instead and the load moves from `%cond.false3459` to `%cond.between` as the updated CHECK lines expect.

Fixes #398
