### PR TITLE
LowerGEPForPrivMem: treat array-of-i8 GEPs as byte offsets

### DIFF
--- a/IGC/Compiler/CISACodeGen/LowerGEPForPrivMem.cpp
+++ b/IGC/Compiler/CISACodeGen/LowerGEPForPrivMem.cpp
@@ -1122,9 +1122,10 @@ std::pair<unsigned int, Type *> TransposeHelper::getArrSizeAndEltType(Type *T) {
   return std::make_pair(arr_sz, retTy);
 }
 
-Type *TransposeHelper::getFirstNonScalarSourceElementType(const GetElementPtrInst &GEP) {
+Type *TransposeHelper::getFirstNonScalarSourceElementType(const GetElementPtrInst &GEP,
+                                                          bool ignoreSourceElementType) {
   Type *currTy = GEP.getSourceElementType();
-  if (getArrSizeAndEltType(currTy).first > 1)
+  if (!ignoreSourceElementType && getArrSizeAndEltType(currTy).first > 1)
     return currTy;
 
   const Value *base = GEP.getPointerOperand()->stripPointerCasts();
@@ -1161,13 +1162,21 @@ void TransposeHelper::handleGEPInst(llvm::GetElementPtrInst *pGEP, llvm::Value *
   IRBuilder<> IRB(pGEP);
   Value *pScalarizedIdx = IRB.getInt32(0);
 
-  // If the GEP is on i8, its index is a byte offset and must be converted to an element index of the underlying base
-  // type.
-  if (pGEP->getSourceElementType()->isIntegerTy(8)) {
+  // A GEP indexes bytes when the innermost scalar of its source element type is i8: either
+  // bare i8, or an (possibly nested) array of i8 as produced by LLVM's canonicalization of
+  // `gep T, ptr, %i` into `gep [sizeof(T) x i8], ptr, %i`.  Its accumulated offset is a byte
+  // offset and must be converted to an element index of the underlying base type.
+  Type *gepSrcTy = pGEP->getSourceElementType();
+  Type *gepInnermostTy = gepSrcTy;
+  while (gepInnermostTy->isArrayTy())
+    gepInnermostTy = gepInnermostTy->getArrayElementType();
+
+  if (gepInnermostTy->isIntegerTy(8)) {
+    const bool isByteArrayGEP = !gepSrcTy->isIntegerTy(8);
     uint32_t elementBytes = m_idxUnitBytes;
     // if elementBytes is 0, it means that scalarized index counts innermost scalas
     if (elementBytes == 0) {
-      Type *elementTy = getFirstNonScalarSourceElementType(*pGEP);
+      Type *elementTy = getFirstNonScalarSourceElementType(*pGEP, isByteArrayGEP);
       while (elementTy->isStructTy() || elementTy->isArrayTy() || elementTy->isVectorTy()) {
         elementTy = getArrSizeAndEltType(elementTy).second;
       }
@@ -1175,8 +1184,30 @@ void TransposeHelper::handleGEPInst(llvm::GetElementPtrInst *pGEP, llvm::Value *
       elementBytes = (uint32_t)m_DL.getTypeAllocSize(elementTy);
     }
 
-    // The 1st operand is the byte offset, convert bytes to element count.
-    Value *byteIndex = IRB.CreateZExtOrTrunc(pGEP->getOperand(1), IRB.getInt32Ty());
+    // Accumulate the GEP's byte offset.  Since the innermost element occupies one byte, the
+    // aggregate walk yields bytes directly: `gep [4 x i8], ptr, %i` gives %i * 4.  For bare
+    // i8 the walk degenerates to the single index operand.
+    Value *byteIndex = IRB.getInt32(0);
+    Type *ByteTy = gepSrcTy;
+    for (unsigned i = 0, e = pGEP->getNumIndices(); i < e; ++i) {
+      auto GepOpnd = IRB.CreateZExtOrTrunc(pGEP->getOperand(i + 1), IRB.getInt32Ty());
+      auto [arr_sz, eltTy] = getArrSizeAndEltType(ByteTy);
+
+      byteIndex = IRB.CreateAdd(byteIndex, GepOpnd);
+      byteIndex = IRB.CreateMul(byteIndex, IRB.getInt32(arr_sz));
+
+      ByteTy = eltTy;
+    }
+    // Fewer indices than nesting levels: the remaining dimensions still scale the offset.
+    while (ByteTy->isArrayTy()) {
+      auto [arr_sz, eltTy] = getArrSizeAndEltType(ByteTy);
+
+      byteIndex = IRB.CreateMul(byteIndex, IRB.getInt32(arr_sz));
+
+      ByteTy = eltTy;
+    }
+
+    // Convert bytes to element count.
     if (elementBytes > 1)
       byteIndex = IRB.CreateUDiv(byteIndex, IRB.getInt32(elementBytes));
 

--- a/IGC/Compiler/CISACodeGen/LowerGEPForPrivMem.hpp
+++ b/IGC/Compiler/CISACodeGen/LowerGEPForPrivMem.hpp
@@ -197,6 +197,10 @@ protected:
 private:
   bool m_vectorIndex;
   std::pair<unsigned int, llvm::Type *> getArrSizeAndEltType(llvm::Type *T);
-  llvm::Type *getFirstNonScalarSourceElementType(const llvm::GetElementPtrInst &GEP);
+  // \p ignoreSourceElementType skips the GEP's own source element type and recovers the
+  // type from the base object instead.  A byte-indexing GEP's source element type says
+  // nothing about the element size of the object it indexes into.
+  llvm::Type *getFirstNonScalarSourceElementType(const llvm::GetElementPtrInst &GEP,
+                                                 bool ignoreSourceElementType = false);
 };
 } // namespace IGC

--- a/IGC/Compiler/tests/PrivateMemoryResolution/arrayof_i8_gep_byte_offset.ll
+++ b/IGC/Compiler/tests/PrivateMemoryResolution/arrayof_i8_gep_byte_offset.ll
@@ -1,0 +1,31 @@
+;=========================== begin_copyright_notice ============================
+;
+; Copyright (C) 2026 Intel Corporation
+;
+; SPDX-License-Identifier: MIT
+;
+;============================ end_copyright_notice =============================
+
+; RUN: igc_opt --opaque-pointers --igc-private-mem-resolution --platformbmg -S %s | FileCheck %s
+
+; A GEP whose source element type is an array of i8 carries a byte offset, exactly
+; like a GEP on bare i8: LLVM canonicalizes `gep T, ptr, %i` into
+; `gep [sizeof(T) x i8], ptr, %i`. Here the offset is 3 * 4 = 12 bytes into an
+; alloca of i32 lanes, so the scalarized index must be 12 / 4 = 3 lanes, not 12.
+
+; CHECK: mul i32 %{{.*}}, 4
+; CHECK-NOT: mul i32 12,
+; CHECK: mul i32 3,
+
+define spir_kernel void @test() {
+  %a = alloca [8 x i32], align 4
+  %p = getelementptr inbounds [4 x i8], ptr %a, i64 3
+  %q = getelementptr inbounds i32, ptr %p, i64 0
+  %v = load i32, ptr %q, align 4
+  ret void
+}
+
+!igc.functions = !{!1}
+!1 = !{ptr @test, !2}
+!2 = !{!3}
+!3 = !{!"function_type", i32 0}


### PR DESCRIPTION
Restore SoA promotion for byte-indexed private arrays.

LLVM canonicalizes `gep T, ptr, %i` into `gep [sizeof(T) x i8], ptr, %i`, so on an
LLVM 23+ SPIR-V toolchain essentially every private-array access reaches IGC as a
GEP whose source element type is an i8 array. `TransposeHelper::handleGEPInst`
converts a byte offset to a lane index only when that type is bare i8; an `[N x i8]`
source element type instead falls into the aggregate walk, which multiplies the index
by N and passes the result to HandleAllocaSources in units of the alloca's element
type, producing an N-times over-stride.

Commit d73553dfd19d ("Skip SOA Promotion if alloca and GEP types mismatches") prevents
that miscompile by disabling SoA promotion whenever the array-stripped GEP source
element type does not match the alloca element type. Combined with the canonicalization
above, that guard now turns off SoA promotion for effectively every private array. This
change fixes the indexing itself, so promotion is retained instead of abandoned.

The indexing defect is still reachable on master. The added lit test
IGC/Compiler/tests/PrivateMemoryResolution/arrayof_i8_gep_byte_offset.ll fails before
this change with lane index 12 instead of 3, and passes after. That test is a
constructed IR case: a second GEP moves parentLevelInst off the byte GEP so the
size-mismatch guard passes, and a constant index avoids the dynamic-index guard. We
have not observed a real kernel hitting this path on master.

The fix recognizes a source element type whose innermost scalar is i8 as byte indexing,
accumulates the GEP's byte offset over all of its indices, and divides by the element
size. For a bare i8 source element type the accumulation reduces to the single index
operand and the emitted IR is unchanged.

check-igc and check-ocloc show no other change.

Refs #429
