### PR TITLE
Handle multiple opencl-c.h headers found during configure

### DIFF
--- a/IGC/cmake/igc_find_opencl_clang.cmake
+++ b/IGC/cmake/igc_find_opencl_clang.cmake
@@ -25,6 +25,32 @@ endif()
 set(COMMON_CLANG_LIB_NAME_WITH_PREFIX "lib${COMMON_CLANG_LIBRARY_NAME}")
 set(COMMON_CLANG_LIB_FULL_NAME "${COMMON_CLANG_LIB_NAME_WITH_PREFIX}*${CMAKE_SHARED_LIBRARY_SUFFIX}")
 
+# file(GLOB_RECURSE) yields a list, and an installation may legitimately ship
+# more than one opencl-c.h, e.g. <prefix>/include/cclang/opencl-c.h from
+# opencl-clang next to <prefix>/lib/clang/<ver>/include/opencl-c.h from clang
+# itself. Every consumer of ${opencl-header} expects exactly one path and
+# dereferences it unquoted, so a list silently shifts their arguments. Reduce
+# the glob result in _var to the lexicographically first candidate so the
+# choice is deterministic, and honour the IGC_OPTION__OPENCL_HEADER_PATH
+# override on every branch, not just CCLANG_FROM_SYSTEM.
+function(igc_select_opencl_header _var)
+  if(DEFINED IGC_OPTION__OPENCL_HEADER_PATH)
+    if(NOT EXISTS "${IGC_OPTION__OPENCL_HEADER_PATH}")
+      message(FATAL_ERROR "[IGC] : couldn't find opencl-c.h in user defined path IGC_OPTION__OPENCL_HEADER_PATH=${IGC_OPTION__OPENCL_HEADER_PATH}")
+    endif()
+    set(${_var} "${IGC_OPTION__OPENCL_HEADER_PATH}" PARENT_SCOPE)
+    return()
+  endif()
+  set(_found "${${_var}}")
+  list(LENGTH _found _len)
+  if(_len GREATER 1)
+    list(SORT _found)
+    list(GET _found 0 _first)
+    message(STATUS "[IGC] : Found ${_len} opencl-c.h candidates: ${_found} - using ${_first}. Set IGC_OPTION__OPENCL_HEADER_PATH to select another one.")
+    set(${_var} "${_first}" PARENT_SCOPE)
+  endif()
+endfunction()
+
 find_library(CCLANG_FROM_SYSTEM ${COMMON_CLANG_LIBRARY_NAME})
 
 ### Check if user manual setup some of flag
@@ -141,6 +167,7 @@ if(CCLANG_FROM_SYSTEM)
       # Get path to opencl-c.h based on the location of CLANG_EXE
       get_filename_component(CLANG_EXE_PARENT_DIR ${CLANG_EXE} DIRECTORY)
       file(GLOB_RECURSE opencl-header ${CLANG_EXE_PARENT_DIR}/../*opencl-c.h)
+      igc_select_opencl_header(opencl-header)
       if(opencl-header)
         message(STATUS "[IGC] Found opencl-c.h: ${opencl-header}")
       else(opencl-header)
@@ -202,6 +229,7 @@ elseif(${CCLANG_BUILD_PREBUILDS})
 
     # Find opencl-header recursively in CCLANG_BUILD_PREBUILDS_DIR
     file(GLOB_RECURSE opencl-header ${CCLANG_BUILD_PREBUILDS_DIR}/*opencl-c.h)
+    igc_select_opencl_header(opencl-header)
   else()
     message(FATAL_ERROR "[IGC] : The clang-tool(${CLANG_TOOL_VERSION}) from prebuilts is newer than llvm(${LLVM_PACKAGE_VERSION}) version for IGC.")
   endif()

--- a/IGC/cmake/tests/opencl_header_multiple/CMakeLists.txt
+++ b/IGC/cmake/tests/opencl_header_multiple/CMakeLists.txt
@@ -1,0 +1,110 @@
+#=========================== begin_copyright_notice ============================
+#
+# Copyright (C) 2026 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+#
+#============================ end_copyright_notice =============================
+
+# Reproduces: a toolchain that provides more than one opencl-c.h breaks configure
+# (intel/intel-graphics-compiler#314).
+#
+# IGC has no CMake test harness - there is no top-level enable_testing() and no
+# add_test() anywhere in the tree - so this reproducer is a standalone project
+# that has to be configured by hand:
+#
+#   cmake -S IGC/cmake/tests/opencl_header_multiple -B <some-build-dir>
+#
+# It succeeds (configure exits 0) when the module under test behaves and fails
+# with a FATAL_ERROR naming the scenario otherwise. No compiler, no LLVM and no
+# network access are needed; everything the module under test looks at is
+# generated below.
+#
+# Each scenario runs igc_find_opencl_clang.cmake in a child configure (probe/)
+# and asserts on what that child reported and on its exit status. Doing it in a
+# child is what makes the assertions independent: a hard CMake error inside one
+# of the replayed consumers would otherwise abort the whole run and hide every
+# later check.
+
+cmake_minimum_required(VERSION 3.13)
+project(igc_opencl_header_multiple NONE)
+
+set(_fake "${CMAKE_CURRENT_BINARY_DIR}/fake-prebuilds")
+
+# A prebuilds directory that legitimately ships two opencl-c.h: the one
+# opencl-clang installs under include/cclang, and the one clang itself installs
+# under lib/clang/<version>/include. This is the layout from the bug report.
+set(_cclangHeader "${_fake}/include/cclang/opencl-c.h")
+set(_clangHeader  "${_fake}/lib/clang/17.0.6/include/opencl-c.h")
+file(WRITE "${_cclangHeader}" "// fake opencl-clang header\n")
+file(WRITE "${_clangHeader}" "// fake clang header\n")
+file(WRITE "${_fake}/include/cclang/opencl-c-base.h" "// fake base header\n")
+file(WRITE "${_fake}/lib/libopencl-clang.so" "")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/clang-stub/clang"
+     "#!/bin/sh\necho \"clang version 17.0.5 (fake)\" 1>&2\n")
+file(COPY "${CMAKE_CURRENT_BINARY_DIR}/clang-stub/clang" DESTINATION "${_fake}/bin"
+     FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE)
+
+# Guard against the fixture silently losing its point.
+file(GLOB_RECURSE _candidates "${_fake}/*opencl-c.h")
+list(LENGTH _candidates _candidateCount)
+if(_candidateCount LESS 2)
+  message(FATAL_ERROR "fixture is broken: the fake prebuilds dir must contain at least two "
+                      "opencl-c.h, found ${_candidateCount}: ${_candidates}")
+endif()
+
+# Runs the probe project and returns its exit status plus the values it reported.
+function(run_probe scenario)
+  set(_bin "${CMAKE_CURRENT_BINARY_DIR}/probe-${scenario}")
+  file(REMOVE_RECURSE "${_bin}")
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -S "${CMAKE_CURRENT_LIST_DIR}/probe" -B "${_bin}"
+            "-DIGC_TEST_PREBUILDS_DIR=${_fake}" ${ARGN}
+    OUTPUT_VARIABLE _out ERROR_VARIABLE _err RESULT_VARIABLE _rc)
+  set(_log "${_out}${_err}")
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/probe-${scenario}.log" "${_log}")
+  set(PROBE_RC "${_rc}" PARENT_SCOPE)
+  foreach(_key HEADER_COUNT HEADER_VALUE HEADER_DIR BIF_SRC_COUNT)
+    set(_value "")
+    if(_log MATCHES "IGC_TEST_${_key}=([^\r\n]*)")
+      set(_value "${CMAKE_MATCH_1}")
+    endif()
+    set("PROBE_${_key}" "${_value}" PARENT_SCOPE)
+  endforeach()
+endfunction()
+
+function(expect scenario what expected actual)
+  if(NOT "${expected}" STREQUAL "${actual}")
+    message(FATAL_ERROR "[${scenario}] ${what}: expected '${expected}', got '${actual}'\n"
+                        "see ${CMAKE_CURRENT_BINARY_DIR}/probe-${scenario}.log")
+  endif()
+endfunction()
+
+# --------------------------------------------------------------------------
+# Scenario 1: two headers, no override. The module must reduce them to exactly
+# one path, and deterministically the same one, so that every consumer of
+# ${opencl-header} keeps working. Before the fix the glob result stays a list,
+# get_filename_component() is handed three arguments and the child configure
+# dies with "unknown component".
+# --------------------------------------------------------------------------
+run_probe(multiple)
+expect(multiple "number of opencl-c.h paths" "1" "${PROBE_HEADER_COUNT}")
+expect(multiple "selected opencl-c.h" "${_cclangHeader}" "${PROBE_HEADER_VALUE}")
+expect(multiple "child configure exit status" "0" "${PROBE_RC}")
+if("${PROBE_BIF_SRC_COUNT}" STREQUAL "" OR PROBE_BIF_SRC_COUNT LESS 1)
+  message(FATAL_ERROR "[multiple] get_bif_src_list() produced '${PROBE_BIF_SRC_COUNT}' entries: "
+                      "its arguments were bound to the wrong values")
+endif()
+
+# --------------------------------------------------------------------------
+# Scenario 2: the documented IGC_OPTION__OPENCL_HEADER_PATH override. It has to
+# be honoured on the prebuilds branch too, which is the branch the bug was
+# reported on; before the fix the override was only consulted when opencl-clang
+# came from the system, and the glob won here regardless of it.
+# --------------------------------------------------------------------------
+run_probe(override "-DIGC_OPTION__OPENCL_HEADER_PATH=${_clangHeader}")
+expect(override "number of opencl-c.h paths" "1" "${PROBE_HEADER_COUNT}")
+expect(override "selected opencl-c.h" "${_clangHeader}" "${PROBE_HEADER_VALUE}")
+expect(override "child configure exit status" "0" "${PROBE_RC}")
+
+message(STATUS "PASS: opencl-c.h selection is single-valued, deterministic and overridable")

--- a/IGC/cmake/tests/opencl_header_multiple/probe/CMakeLists.txt
+++ b/IGC/cmake/tests/opencl_header_multiple/probe/CMakeLists.txt
@@ -1,0 +1,57 @@
+#=========================== begin_copyright_notice ============================
+#
+# Copyright (C) 2026 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+#
+#============================ end_copyright_notice =============================
+
+# Inner project of the opencl_header_multiple reproducer. It is configured once
+# per scenario by the driver in the parent directory, which reads the values
+# reported below and the exit status. Everything it needs is passed in with -D.
+#
+# This has to be a project() rather than a `cmake -P` script because
+# igc_find_opencl_clang.cmake calls add_library()/set_property(TARGET ...),
+# which script mode does not provide.
+
+cmake_minimum_required(VERSION 3.13)
+project(igc_opencl_header_probe NONE)
+
+get_filename_component(IGC_SRC "${CMAKE_CURRENT_LIST_DIR}/../../../../.." ABSOLUTE)
+list(APPEND CMAKE_MODULE_PATH "${IGC_SRC}/IGC/cmake" "${IGC_SRC}/IGC/BiFModule/cmake")
+
+# Enough of the surrounding build for igc_find_opencl_clang.cmake to reach the
+# prebuilds branch, which is the branch the bug was reported on.
+set(IGC_BUILD__GFX_DEV_SRC_DIR "${CMAKE_CURRENT_BINARY_DIR}/no-such-dir")
+set(LLVM_SOURCE_DIR            "${CMAKE_CURRENT_BINARY_DIR}/no-such-dir")
+set(LLVM_VERSION_MAJOR 17)
+set(LLVM_VERSION_MINOR 0)
+set(LLVM_VERSION_PATCH 6)
+set(IGC_BUILD__CLANG_VERSION "17.0.6")
+set(IGC_BUILD__CLANG_VERSION_MAJOR "17")
+set(CCLANG_BUILD_PREBUILDS TRUE)
+set(CCLANG_BUILD_PREBUILDS_DIR "${IGC_TEST_PREBUILDS_DIR}")
+
+include(igc_find_opencl_clang)
+
+list(LENGTH opencl-header _headerCount)
+message(STATUS "IGC_TEST_HEADER_COUNT=${_headerCount}")
+message(STATUS "IGC_TEST_HEADER_VALUE=${opencl-header}")
+
+# The two consumers that break, replayed exactly as they appear in the tree at
+# the time the bug was reported, i.e. with an unquoted dereference. That is what
+# makes them a test of the value rather than of the quoting: a single path works
+# unquoted, a list does not.
+#
+# IGC/BiFModule/CMakeLists.txt - hard error, this is the traceback in the report.
+get_filename_component(opencl-headers-dir ${opencl-header} DIRECTORY)
+message(STATUS "IGC_TEST_HEADER_DIR=${opencl-headers-dir}")
+
+# IGC/BiFModule/cmake/BiFModuleCache.cmake - silent argument shift: with a list
+# here get_bif_src_list() binds its arguments to the wrong values and the BiF
+# checksum target ends up with no dependencies at all.
+include(BiFMCGetListFiles)
+set(BiFModule_SRC_LIST "")
+get_bif_src_list(${opencl-header} "${IGC_SRC}/IGC/BiFModule/" BiFModule_SRC_LIST)
+list(LENGTH BiFModule_SRC_LIST _srcCount)
+message(STATUS "IGC_TEST_BIF_SRC_COUNT=${_srcCount}")


### PR DESCRIPTION
`file(GLOB_RECURSE opencl-header ...)` in `IGC/cmake/igc_find_opencl_clang.cmake` returns a list whenever an installation ships more than one `opencl-c.h`, for example `<prefix>/include/cclang/opencl-c.h` from opencl-clang next to `<prefix>/lib/clang/<ver>/include/opencl-c.h` from clang itself. Every consumer of `${opencl-header}` expects one path and dereferences it unquoted, so on the prebuilds branch configure dies with

```
CMake Error at IGC/BiFModule/CMakeLists.txt:57 (get_filename_component):
  get_filename_component unknown component <second header>
```

and on the `CCLANG_FROM_SYSTEM` branch the list instead silently shifts the arguments of `get_bif_src_list()`. `IGC_OPTION__OPENCL_HEADER_PATH` was only consulted on the `CCLANG_FROM_SYSTEM` branch, so it could not be used to work around the prebuilds case where this was reported.

Add `igc_select_opencl_header()` after both globs: honour `IGC_OPTION__OPENCL_HEADER_PATH` on every branch, and when the glob returned several candidates sort them, keep the first and print the choice.

IGC has no CMake test harness, so the reproducer is a standalone project that needs no compiler, LLVM or network:

```
cmake -S IGC/cmake/tests/opencl_header_multiple -B /tmp/b
```

It builds a fake prebuilds tree with two `opencl-c.h`, runs the module under test in a child configure per scenario and asserts on what it reported. On master it fails with `number of opencl-c.h paths: expected '1', got '2'` followed by the traceback above; with this change it exits 0, including the override scenario.

#336 is a duplicate of this.

Fixes #314
