### PR TITLE
Do not crash on SPIR-V BuiltIns declared narrower than size_t

### DIFF
--- a/IGC/Compiler/Optimizer/BuiltInFuncImport.cpp
+++ b/IGC/Compiler/Optimizer/BuiltInFuncImport.cpp
@@ -593,6 +593,44 @@ void BIImport::addOCLObjectCastFunctionDefinitions(llvm::Module &M) {
   }
 }
 
+// A SPIR-V module may declare a size_t BuiltIn narrower than BiFModule defines it (e.g.
+// LocalInvocationId as OpTypeVector %uint 3 under Physical64). Itanium mangling omits the return
+// type, so linking BiF silently replaces the i32 declaration with the i64 definition, leaving
+// calls whose FunctionType disagrees with their callee. getCalledFunction() type-checks and
+// returns null for such calls, so they read as indirect: the builtin's implicit arguments
+// (LOCAL_ID_X/Y/Z) are never propagated to the kernel and AddImplicitArgs installs a null call
+// operand (SIGSEGV), or, for builtins needing no implicit argument (WorkgroupId, GlobalOffset),
+// the i64 results are legalized and bitcast back into narrow lanes and silently miscompiled.
+// Rebuild such calls against the linked-in definition and convert the result back to the declared
+// width; every builtin reachable here is an unsigned id or size, so zext is correct on widening.
+// Only integer return types are repaired here. Parameter mismatches remain with
+// removeFunctionBitcasts(), whose clone-the-body strategy cannot express a return-type change
+// (it would put `ret i64` inside a function declared to return i32).
+static void fixCallsWithMismatchedReturnType(Module &M) {
+  for (Function &F : M)
+    for (Instruction &I : make_early_inc_range(instructions(F))) {
+      CallInst *call = dyn_cast<CallInst>(&I);
+      // A non-null getCalledFunction() means the call already agrees with its callee.
+      if (!call || call->getCalledFunction())
+        continue;
+      Function *callee = dyn_cast<Function>(IGCLLVM::getCalledValue(call)->stripPointerCasts());
+      // Only calls to a linked-in definition can be repaired: genuinely indirect calls cannot,
+      // and against a bare declaration the call site is just as authoritative.
+      if (!callee || callee->isDeclaration() || callee->isVarArg() ||
+          call->getFunctionType()->params() != callee->getFunctionType()->params() ||
+          !call->getType()->isIntegerTy() || !callee->getReturnType()->isIntegerTy())
+        continue;
+      IRBuilder<> builder(call);
+      CallInst *newCall = builder.CreateCall(callee, SmallVector<Value *, 4>(call->args()));
+      newCall->setCallingConv(call->getCallingConv());
+      // The old return attributes describe the old return type, so they must not be carried over.
+      newCall->setAttributes(
+          call->getAttributes().removeAttributesAtIndex(M.getContext(), AttributeList::ReturnIndex));
+      call->replaceAllUsesWith(builder.CreateZExtOrTrunc(newCall, call->getType()));
+      call->eraseFromParent();
+    }
+}
+
 bool BIImport::run(Module &M, CodeGenContext *Ctx, IGC::IGCMD::MetaDataUtils *MdUtils) {
   fixSPIRFunctionsReturnType(M);
 
@@ -636,6 +674,7 @@ bool BIImport::run(Module &M, CodeGenContext *Ctx, IGC::IGCMD::MetaDataUtils *Md
 #endif // BIF_LINK_BC
 
   InitializeBIFlags(M);
+  fixCallsWithMismatchedReturnType(M);
   removeFunctionBitcasts(M);
   fixInvalidBitcasts(M);
   addOCLObjectCastFunctionDefinitions(M);

--- a/IGC/Compiler/tests/BuiltInFuncImport/spirv_builtin_narrow_return_type.ll
+++ b/IGC/Compiler/tests/BuiltInFuncImport/spirv_builtin_narrow_return_type.ll
@@ -1,0 +1,66 @@
+;=========================== begin_copyright_notice ============================
+;
+; Copyright (C) 2026 Intel Corporation
+;
+; SPDX-License-Identifier: MIT
+;
+;============================ end_copyright_notice =============================
+
+; A BuiltIn variable that the SPIR-V spec types as a vector of size_t may legally be declared
+; narrower than the target's size_t, e.g. "OpTypeVector %uint 3" under Physical64. The translator
+; then emits calls returning i32, while BiFModule defines __spirv_BuiltInLocalInvocationId returning
+; i64. Because Itanium mangling does not encode the return type, the definition silently replaces
+; the declaration when BiF is linked in and leaves call sites disagreeing with their callee.
+;
+; Such a call reads as indirect (CallBase::getCalledFunction() type-checks and returns null), which
+; keeps the builtin from being inlined and keeps BuiltinCallGraphAnalysis from propagating the
+; implicit arguments it needs up to the kernel. Check that BIImport instead rebuilds the call
+; against the linked-in definition and truncates the result back to the declared width.
+
+; REQUIRES: llvm-14-plus
+; RUN: igc_opt --opaque-pointers -igc-builtin-import -disable-verify -S < %s | FileCheck %s
+
+; CHECK-LABEL: define spir_kernel void @test_scalar
+; CHECK: [[ID:%.*]] = call{{.*}} i64 @_Z32__spirv_BuiltInLocalInvocationIdi(i32 0)
+; CHECK: [[TR:%.*]] = trunc i64 [[ID]] to i32
+; CHECK: store i32 [[TR]]
+
+define spir_kernel void @test_scalar(ptr addrspace(1) %out) {
+entry:
+  %id = call spir_func i32 @_Z32__spirv_BuiltInLocalInvocationIdi(i32 0)
+  store i32 %id, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+; The shape an OpTypeVector %uint 3 BuiltIn actually translates to. Every element must be truncated
+; before it is inserted, otherwise an i64 ends up in a <3 x i32> and the vector is later legalized
+; into six i32 lanes and bitcast back down to three, silently dropping component 2.
+; CHECK-LABEL: define spir_kernel void @test_vector
+; CHECK: [[X:%.*]] = call{{.*}} i64 @_Z33__spirv_BuiltInGlobalInvocationIdi(i32 0)
+; CHECK: [[XT:%.*]] = trunc i64 [[X]] to i32
+; CHECK: insertelement <3 x i32> undef, i32 [[XT]], i32 0
+; CHECK: [[Y:%.*]] = call{{.*}} i64 @_Z33__spirv_BuiltInGlobalInvocationIdi(i32 1)
+; CHECK: [[YT:%.*]] = trunc i64 [[Y]] to i32
+; CHECK: insertelement <3 x i32> %{{.*}}, i32 [[YT]], i32 1
+; CHECK: [[Z:%.*]] = call{{.*}} i64 @_Z33__spirv_BuiltInGlobalInvocationIdi(i32 2)
+; CHECK: [[ZT:%.*]] = trunc i64 [[Z]] to i32
+; CHECK: insertelement <3 x i32> %{{.*}}, i32 [[ZT]], i32 2
+
+define spir_kernel void @test_vector(ptr addrspace(1) %out) {
+entry:
+  %x = call spir_func i32 @_Z33__spirv_BuiltInGlobalInvocationIdi(i32 0)
+  %v0 = insertelement <3 x i32> undef, i32 %x, i32 0
+  %y = call spir_func i32 @_Z33__spirv_BuiltInGlobalInvocationIdi(i32 1)
+  %v1 = insertelement <3 x i32> %v0, i32 %y, i32 1
+  %z = call spir_func i32 @_Z33__spirv_BuiltInGlobalInvocationIdi(i32 2)
+  %v2 = insertelement <3 x i32> %v1, i32 %z, i32 2
+  store <3 x i32> %v2, ptr addrspace(1) %out, align 16
+  ret void
+}
+
+; No call site may be left returning the narrow type.
+; CHECK-NOT: call{{.*}} i32 @_Z32__spirv_BuiltInLocalInvocationIdi
+; CHECK-NOT: call{{.*}} i32 @_Z33__spirv_BuiltInGlobalInvocationIdi
+
+declare spir_func i32 @_Z32__spirv_BuiltInLocalInvocationIdi(i32)
+declare spir_func i32 @_Z33__spirv_BuiltInGlobalInvocationIdi(i32)

--- a/IGC/ocloc_tests/SPIRV-Asm/BuiltInLocalInvocationId_32bit.spvasm
+++ b/IGC/ocloc_tests/SPIRV-Asm/BuiltInLocalInvocationId_32bit.spvasm
@@ -1,0 +1,46 @@
+;=========================== begin_copyright_notice ============================
+;
+; Copyright (C) 2026 Intel Corporation
+;
+; SPDX-License-Identifier: MIT
+;
+;============================ end_copyright_notice =============================
+
+; LocalInvocationId is declared here as "OpTypeVector %uint 3" under Physical64. That is legal
+; SPIR-V, but it is narrower than the size_t that BiFModule uses for
+; __spirv_BuiltInLocalInvocationId, so after BiF linking the call sites disagreed with the linked-in
+; definition. Those calls then read as indirect, the builtin was never inlined, the implicit
+; arguments it needs were never propagated to the kernel, and AddImplicitArgs built a call with null
+; operands that crashed the compiler outright (no diagnostic, SIGSEGV).
+;
+; The same happens for the other size_t-typed BuiltIns (GlobalInvocationId, GlobalSize,
+; WorkgroupSize, NumWorkgroups) and on every device; dg2 is used here only because it is the device
+; the rest of this suite uses.
+
+; REQUIRES: spirv-as, dg2-supported
+
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: ocloc compile -spirv_input -file %t.spv -device dg2 2>&1 | FileCheck %s
+
+; CHECK-NOT: error
+; CHECK: Build succeeded.
+
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %main "test_local_id_v3uint" %gid
+               OpDecorate %gid BuiltIn LocalInvocationId
+       %uint = OpTypeInt 32 0
+       %void = OpTypeVoid
+     %v3uint = OpTypeVector %uint 3
+    %ptr_inv = OpTypePointer Input %v3uint
+    %ptr_gbl = OpTypePointer CrossWorkgroup %v3uint
+         %ft = OpTypeFunction %void %ptr_gbl
+        %gid = OpVariable %ptr_inv Input
+       %main = OpFunction %void None %ft
+        %out = OpFunctionParameter %ptr_gbl
+      %entry = OpLabel
+       %tid3 = OpLoad %v3uint %gid
+               OpStore %out %tid3
+               OpReturn
+               OpFunctionEnd

--- a/IGC/ocloc_tests/SPIRV-Asm/BuiltInLocalInvocationId_32bit_subgroup_shuffle.spvasm
+++ b/IGC/ocloc_tests/SPIRV-Asm/BuiltInLocalInvocationId_32bit_subgroup_shuffle.spvasm
@@ -1,0 +1,49 @@
+;=========================== begin_copyright_notice ============================
+;
+; Copyright (C) 2026 Intel Corporation
+;
+; SPDX-License-Identifier: MIT
+;
+;============================ end_copyright_notice =============================
+
+; The reporter's original form of the narrow-BuiltIn crash: a 32-bit LocalInvocationId feeding
+; OpSubgroupShuffleINTEL in a kernel with a required sub-group size. Neither the shuffle nor the
+; OpCompositeExtract is needed to trigger the crash (see BuiltInLocalInvocationId_32bit.spvasm), but
+; this form is kept because it pulls in a different set of implicit arguments and because it is what
+; was reported.
+
+; REQUIRES: spirv-as, dg2-supported
+
+; RUN: spirv-as --target-env spv1.1 -o %t.spv %s
+; RUN: ocloc compile -spirv_input -file %t.spv -device dg2 -options "-cl-std=CL2.0" 2>&1 | FileCheck %s
+
+; CHECK-NOT: error
+; CHECK: Build succeeded.
+
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability SubgroupShuffleINTEL
+               OpCapability SubgroupDispatch
+               OpExtension "SPV_INTEL_subgroups"
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %main "test_shuffle_local_id_v3uint" %gid
+               OpExecutionMode %main SubgroupSize 32
+               OpDecorate %gid BuiltIn LocalInvocationId
+       %uint = OpTypeInt 32 0
+       %void = OpTypeVoid
+     %v3uint = OpTypeVector %uint 3
+    %ptr_inv = OpTypePointer Input %v3uint
+    %ptr_gbl = OpTypePointer CrossWorkgroup %uint
+         %ft = OpTypeFunction %void %ptr_gbl
+        %gid = OpVariable %ptr_inv Input
+     %uint_0 = OpConstant %uint 0
+       %main = OpFunction %void None %ft
+        %out = OpFunctionParameter %ptr_gbl
+      %entry = OpLabel
+       %tid3 = OpLoad %v3uint %gid
+        %tid = OpCompositeExtract %uint %tid3 0
+         %s1 = OpSubgroupShuffleINTEL %uint %tid %uint_0
+               OpStore %out %s1
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
#395 was closed because the input is out of spec: under `Physical64` the OpenCL SPIR-V Environment spec requires `LocalInvocationId` to be a vector of 64-bit integers, and the module declares it 32-bit. Agreed on the input. This PR is about what IGC does with it, which today is a `SIGSEGV` with no output (exit 139 on dg2, rpl-s, bmg-g21 and pvc) rather than a diagnostic.

Mechanism: BiFModule defines `__spirv_BuiltInLocalInvocationId` returning i64 while the module declares it returning i32. Itanium mangling omits the return type, so linking BiF silently replaces the declaration with the i64 definition and leaves calls whose `FunctionType` disagrees with their callee. `getCalledFunction()` type-checks and returns null for those, they read as indirect calls, the builtin's implicit arguments (`LOCAL_ID_X/Y/Z`) are never propagated to the kernel, and `AddImplicitArgs` installs a null call operand. For builtins that need no implicit argument (`WorkgroupId`, `GlobalOffset`) there is no crash; the i64 result is legalized and bitcast into narrow lanes, which is a silent miscompile.

`fixCallsWithMismatchedReturnType()` in `BIImport::run()` rebuilds such calls against the linked-in definition and converts the result to the declared width. Every builtin reachable here is an unsigned id or size, so zext is correct on widening. Parameter mismatches stay with `removeFunctionBitcasts()`.

Marked draft for one decision: this makes IGC accept the out-of-spec module silently, which is the behaviour the tests lock in. If rejecting it with an error at the same point is preferred, I will change it to that; either way the null dereference goes away.

Tests: one `check-igc` test on the repaired IR, and two ocloc `.spvasm` tests (`REQUIRES: spirv-as`) that exit -11 on master and print `Build succeeded.` with this change.

Related: #395
